### PR TITLE
Allow UploadFileJob to take S3 urls

### DIFF
--- a/lib/rocket_job/jobs/upload_file_job.rb
+++ b/lib/rocket_job/jobs/upload_file_job.rb
@@ -93,17 +93,12 @@ module RocketJob
       end
 
       def file_exists
-        return if upload_file_name.nil? || cloud_url?(upload_file_name) || File.exist?(upload_file_name)
+        return if upload_file_name.nil? 
+        uri = URI.parse(upload_file_name)
+        return unless uri.scheme.nil? || uri.scheme == 'file'
+        return if File.exist?(upload_file_name) 
         errors.add(:upload_file_name, "Upload file: #{upload_file_name} does not exist.")
       end
-
-      def cloud_url?(filename)
-        uri = URI.parse(filename)
-        return true if uri.scheme.downcase == 's3'
-        false
-      rescue
-        false
-      end
-    end
+   end
   end
 end

--- a/lib/rocket_job/jobs/upload_file_job.rb
+++ b/lib/rocket_job/jobs/upload_file_job.rb
@@ -91,7 +91,7 @@ module RocketJob
       end
 
       def file_exists
-        return if upload_file_name.nil? || File.exist?(upload_file_name)
+        return if upload_file_name.nil? || File.exist?(upload_file_name) || upload_file_name =~ /^s3:/
         errors.add(:upload_file_name, "Upload file: #{upload_file_name} does not exist.")
       end
     end

--- a/lib/rocket_job/jobs/upload_file_job.rb
+++ b/lib/rocket_job/jobs/upload_file_job.rb
@@ -1,4 +1,6 @@
 require 'fileutils'
+require 'uri'
+
 begin
   require 'iostreams'
 rescue LoadError
@@ -91,8 +93,16 @@ module RocketJob
       end
 
       def file_exists
-        return if upload_file_name.nil? || File.exist?(upload_file_name) || upload_file_name =~ /^s3:/
+        return if upload_file_name.nil? || cloud_url?(upload_file_name) || File.exist?(upload_file_name)
         errors.add(:upload_file_name, "Upload file: #{upload_file_name} does not exist.")
+      end
+
+      def cloud_url?(filename)
+        uri = URI.parse(filename)
+        return true if uri.scheme.downcase == 's3'
+        false
+      rescue
+        false
       end
     end
   end

--- a/test/jobs/upload_file_job_test.rb
+++ b/test/jobs/upload_file_job_test.rb
@@ -55,6 +55,14 @@ module Jobs
           assert_equal ['Upload file: /tmp/blah does not exist.'], job.errors.messages[:upload_file_name]
         end
 
+        it 'allows AWS S3 urls for upload_file_name' do
+          job = RocketJob::Jobs::UploadFileJob.new(
+            job_class_name:   UploadFileJobTest::TestJob.to_s,
+            upload_file_name: 's3:/foo/blah'
+          )
+          assert job.valid?
+        end
+
         it 'validates job_class_name' do
           job = RocketJob::Jobs::UploadFileJob.new(job_class_name: UploadFileJobTest::BadJob.to_s)
           refute job.valid?

--- a/test/jobs/upload_file_job_test.rb
+++ b/test/jobs/upload_file_job_test.rb
@@ -55,7 +55,7 @@ module Jobs
           assert_equal ['Upload file: /tmp/blah does not exist.'], job.errors.messages[:upload_file_name]
         end
 
-        it 'allows AWS S3 urls for upload_file_name' do
+        it 'allows urls other than file for upload_file_name' do
           job = RocketJob::Jobs::UploadFileJob.new(
             job_class_name:   UploadFileJobTest::TestJob.to_s,
             upload_file_name: 's3:/foo/blah'
@@ -63,10 +63,10 @@ module Jobs
           assert job.valid?
         end
 
-        it 'doesnt allow non-s3 urls for upload_file_name' do
+        it 'checks the filesystem if the url scheme is file for upload_file_name' do
           job = RocketJob::Jobs::UploadFileJob.new(
             job_class_name:   UploadFileJobTest::TestJob.to_s,
-            upload_file_name: 'ftp:/foo/blah'
+            upload_file_name: 'file:/foo/blah'
           )
           refute job.valid?
         end

--- a/test/jobs/upload_file_job_test.rb
+++ b/test/jobs/upload_file_job_test.rb
@@ -63,6 +63,14 @@ module Jobs
           assert job.valid?
         end
 
+        it 'doesnt allow non-s3 urls for upload_file_name' do
+          job = RocketJob::Jobs::UploadFileJob.new(
+            job_class_name:   UploadFileJobTest::TestJob.to_s,
+            upload_file_name: 'ftp:/foo/blah'
+          )
+          refute job.valid?
+        end
+
         it 'validates job_class_name' do
           job = RocketJob::Jobs::UploadFileJob.new(job_class_name: UploadFileJobTest::BadJob.to_s)
           refute job.valid?


### PR DESCRIPTION
* allow job to be valid if a filename starts with "s3:"


### Description of changes

Relax the `file exists` validation in the UploadFileJob so that if the filename starts with "s3" it bypasses checking if the file exists on the local filesystem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
