### PR TITLE
Add CLAUDE.md and architecture guide to CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`rocketjob` is a Ruby gem: a distributed, MongoDB-backed batch processing system. Jobs are Mongoid documents persisted to MongoDB; servers pull queued jobs and run them across worker threads. There is no Rails app here, only the library plus its test suite. The web UI (Mission Control) and Tabular plugins live in separate gems.
+
+The primary public interface is `RocketJob::Job`; capabilities are added by mixing in modules such as `RocketJob::Batch`. Treat that surface (subclassing `Job`, opt-in mixins, typed fields, `#perform`, queuing/downloading, documented state transitions) as the stable contract; everything under `Plugins`, `Sliced`, and the runtime classes is internal.
+
+## Why this design
+
+Context worth knowing before changing core behavior:
+
+- **Two tiers of jobs.** Simple jobs (`RocketJob::Job`) are conventional background jobs like other frameworks offer. Batch jobs (`include RocketJob::Batch`) are the real point of Rocket Job: a single job's input is uploaded into a dynamically created MongoDB collection, split into slices, and processed concurrently across thousands of workers (often Docker containers). Output is written back to MongoDB the same way.
+- **Why MongoDB.** Its atomic `find_and_modify` lets thousands of nodes claim work without colliding, and it spills from memory to disk, which is essential for very large files. Rocket Job was built because Sidekiq/Redis could not scale this way (Redis was single-threaded and could not overflow to disk). Also supports AWS DocumentDB.
+- **Why Mongoid.** Jobs are documents with real, typed, validated fields, not an untyped hash of arguments.
+- **Backward compatibility is a priority.** Only break it in a major release, ideally with a deprecation path first. Most forced changes come from breaking changes in MongoDB/Mongoid. When adding persisted fields to a plugin, give them defaults so existing jobs in the database still load.
+
+A class diagram of the core relationships is in [CONTRIBUTING.md](CONTRIBUTING.md) under "Architecture".
+
+## Commands
+
+Tests require a running MongoDB on `127.0.0.1:27017` (see `docker-compose.yml`: `docker compose up -d`). Test config is `test/config/mongoid.yml` and the suite drops/recreates collections on load.
+
+- Run full suite (against current `Gemfile`): `bundle exec rake test`
+- Run one test file: `bundle exec ruby -Itest -Ilib test/job_test.rb`
+- Run one test by name: `bundle exec ruby -Itest -Ilib test/job_test.rb -n /pattern/`
+- Lint: `bundle exec rubocop` (config in `.rubocop.yml`)
+- Test logs go to `test.log` (not stdout); use it to debug failures.
+
+`rake` with no args runs the full matrix via Appraisal, not a single test run. Don't use bare `rake` for quick iteration.
+
+### Multi-version testing (Appraisal)
+
+CI runs against multiple Mongoid/Rails/Ruby combinations defined in `Appraisals` (Mongoid 8.1, 9.0, 9.1) with generated gemfiles in `gemfiles/`. To target one combination:
+
+- `BUNDLE_GEMFILE=gemfiles/mongoid_9.1.gemfile bundle exec rake test`
+- Regenerate gemfiles after editing `Appraisals`: `bundle exec appraisal install`
+
+## Architecture
+
+### Jobs are composed from plugin modules
+
+`RocketJob::Job` ([lib/rocket_job/job.rb](lib/rocket_job/job.rb)) is deliberately near-empty: it `include`s a stack of plugin modules from `Plugins::Job::*` (Model, Persistence, Callbacks, Logger, StateMachine, Worker, Throttle, ...). User jobs subclass `RocketJob::Job` and implement `#perform`. This composition pattern is central: behavior lives in `lib/rocket_job/plugins/`, not in the `Job` class itself. Optional plugins (`Cron`, `Singleton`, `Retry`, `ProcessingWindow`, `ThrottleDependentJobs`) are mixed in per-job by the user.
+
+State transitions (queued → running → completed/failed/aborted/paused) are driven by the `aasm` gem via the StateMachine plugins.
+
+### Batch jobs
+
+Including `RocketJob::Batch` ([lib/rocket_job/batch.rb](lib/rocket_job/batch.rb)) turns a job into a parallel one: input is split into *slices* processed concurrently by many workers. Slices are stored in a **separate Mongo collection/client** (`rocketjob_slices`, distinct from the `rocketjob` client) — see `lib/rocket_job/sliced/`. Input/output are organized by **categories** (`RocketJob::Category::Input`/`Output`, configured via `input_category`/`output_category`), each with its own serializer (plain, compressed, encrypted, bzip2), file format, and collection. `lib/rocket_job/batch/io.rb` handles `upload`/`download`.
+
+### Runtime: Supervisor → WorkerPool → Workers
+
+- `Supervisor` ([lib/rocket_job/supervisor.rb](lib/rocket_job/supervisor.rb)) is the process entry point (`bin/rocketjob` → `RocketJob::CLI`). It registers a `Server` document, manages the `WorkerPool`, handles signals, and runs the event/subscriber listeners.
+- `Server` is a Mongoid document representing a running process; `Worker` represents one thread. `ThreadWorker` and `RactorWorker` are the execution strategies.
+- Cross-process coordination (shutdown, pause, log-level changes) uses a pub/sub mechanism over MongoDB: `RocketJob::Event` + `Subscriber`/`Subscribers::*`. There is no separate message broker.
+
+### Config and persistence
+
+- `RocketJob::Config.load!(env, mongoid_path, symmetric_encryption_path)` bootstraps Mongoid and Symmetric Encryption (see `test/test_helper.rb` for the canonical call).
+- Two Mongo clients are required in `mongoid.yml`: `rocketjob` (jobs) and `rocketjob_slices` (batch slices).
+- `lib/rocket_job/extensions/` monkey-patches Mongoid/Mongo/Psych. Notably, **BSON Symbols are deliberately unsupported** (Mongoid/MongoDB deprecated them); `test_helper.rb` raises if a Symbol is serialized. Use the `StringifiedSymbol` type / strings for field values.
+
+### Built-in jobs
+
+`lib/rocket_job/jobs/` ships ready-to-use jobs: `DirmonJob` (directory monitor that enqueues jobs for arriving files, paired with `DirmonEntry`), `HousekeepingJob`, `OnDemandJob`/`OnDemandBatchJob` (run arbitrary Ruby), `UploadFileJob`, `CopyFileJob`, `ConversionJob`. The ActiveJob adapter is `lib/rocket_job/extensions/rocket_job_adapter.rb`.
+
+## Documentation
+
+User-facing guides are Jekyll markdown in `docs/` (published to rocketjob.io). Edit these for behavior/usage doc changes; serve locally with `cd docs && bundle update && jekyll serve`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to Rocket Job, great to have you on-board. :tada:
 
-To get you started here are some pointers. 
+To get you started here are some pointers.
 
 ## Questions
 
@@ -17,25 +17,30 @@ Great to have you onboard, looking forward to your help and feedback.
 
 #### Late Adopters
 
-Rocket Job is open source code, the author and contributors do this work when we have the "free time" to do so.
+Rocket Job is open source, maintained by the author and contributors in their spare time and offered to the
+community free of charge. Please keep that in mind when raising issues or requesting features, since there is
+no dedicated team available to take on custom work on demand.
 
-We are not here to write code for some random edge case that you may have. That is the point of Pull Requests
-where you can contribute your own enhancements.
+If you have a specific need, particularly an edge case that is unique to your own environment or job, the
+best way forward is to implement it yourself and open a Pull Request. Contributions of this kind are exactly
+how the project grows, and they are warmly welcomed and appreciated.
 
 ## Documentation
 
-Documentation updates are welcomed by all users of Rocket Job.
+Documentation updates are welcome and appreciated by all users of Rocket Job.
+
+The documentation is a Jekyll site under the `docs` subdirectory, published to [rocketjob.io](https://rocketjob.io).
 
 #### Small changes
 
 For a quick and fairly simple documentation fix the changes can be made entirely online in github.
- 
+
 1. Fork the repository in github.
 2. Look for the markdown file that matches the documentation page to be updated under the `docs` subdirectory.
 3. Click Edit.
 4. Make the change and select preview to see what the changes would look like.
 5. Save the change with a commit message.
-6. Submit a Pull Request back to the Rocket Job repository. 
+6. Submit a Pull Request back to the Rocket Job repository.
 
 #### Complete Setup
 
@@ -47,11 +52,11 @@ documentation would look like locally after any changes.
 3. Change into the documentation directory.
 
        cd rocketjob/docs
-       
+
 4. Install required gems
 
        bundle update
-       
+
 5. Start the Jekyll server
 
        jekyll s
@@ -60,72 +65,280 @@ documentation would look like locally after any changes.
 
 7. Navigate around and find the page to edit. The url usually lines up with the markdown file that
    contains the corresponding text.
-   
+
 8. Edit the files ending in `.md` and refresh the page in the web browser to see the change.
 
-9. Once change are complete commit the changes.
+9. Once changes are complete commit the changes.
 
 10. Push the changes to your forked repository.
 
-11. Submit a Pull Request back to the Rocket Job repository. 
+11. Submit a Pull Request back to the Rocket Job repository.
 
 ## Code Changes
 
-Since changes cannot be made directly to the Rocket Job repository, fork it to your own account on Github. 
+Since changes cannot be made directly to the Rocket Job repository, fork it to your own account on Github.
 
 1. Fork the repository in github.
 2. Clone the repository to your local machine.
 3. Change into the Rocket Job directory.
 
        cd rocketjob
-       
+
 4. Install required gems
 
        bundle update
-       
-5. Run basic tests
+
+5. Rocket Job stores everything in MongoDB, so the tests need a running MongoDB. The quickest way to provide
+   one is to start the container defined in `docker-compose.yml`:
+
+       docker compose up -d
+
+   By default the tests connect to `127.0.0.1:27017` (see `test/config/mongoid.yml`).
+
+6. Run the tests
 
        bundle exec rake test
 
-6. When making a bug fix it is recommended to update the test first, ensure the test fails, and only then
-   make the codefix.
+7. Run the linter
 
-7. Once the tests pass and all code changes are complete, commit the changes.
-   
-8. Push changes to your forked repository.
+       bundle exec rubocop
 
-9. Submit a Pull Request back to the Rocket Job repository. 
+   The minimum supported Ruby is 3.2, so please do not use syntax newer than that under `lib`.
 
+8. When making a bug fix it is recommended to update the test first, ensure the test fails, and only then
+   make the code fix.
+
+9. Once the tests pass and all code changes are complete, commit the changes.
+
+10. Push changes to your forked repository.
+
+11. Submit a Pull Request back to the Rocket Job repository.
 
 ### Full Testing
 
-The above code change steps use the packages in Gemfile. When running all of the tests it needs to run
-tests against all supported gemsets. Appraisal is used manage multiple gemfiles. 
+The steps above use the packages in `Gemfile`. The full suite runs against every supported combination of
+Mongoid, ActiveRecord, and Ruby. [Appraisal](https://github.com/thoughtbot/appraisal) manages the multiple
+gemfiles, which are defined in `Appraisals` and generated into the `gemfiles` folder.
 
-Install all needed gems to run the tests:
+Install all the gemsets needed to run the tests (also regenerates the files in `gemfiles`):
 
-    appraisal install
+    bundle exec appraisal install
 
-The gems are installed into the global gem list.
-The Gemfiles in the `gemfiles` folder are also re-generated.
-
-#### Run Tests
-
-For all supported Rails/ActiveRecord versions:
+Run the tests for all supported versions:
 
     bundle exec rake
 
-Or for specific version one:
+Or for one specific version:
 
-    appraisal moingod_7_1 rake
+    bundle exec appraisal mongoid_9.1 rake test
 
-Or for one particular test file
+Or one particular test file:
 
-    appraisal mongoid_7_1 ruby -I"test" test/job_test.rb
+    bundle exec appraisal mongoid_9.1 ruby -Itest test/job_test.rb
 
-Or down to one test case
+Or down to one test case:
 
-    appraisal mongoid_7_1 ruby -I"test" test/job_test.rb -n "/.requeue_dead_server/"
+    bundle exec appraisal mongoid_9.1 ruby -Itest test/job_test.rb -n "/requeue_dead_server/"
+
+## Philosophy
+
+Rocket Job is **Ruby's missing batch system**. Ordinary background job frameworks run one small task per
+worker, which is fine for sending an email or resizing an image. Rocket Job was built when that model could
+not keep up: processing very large files for a large credit bureau, spread across thousands of concurrent
+workers (often Docker containers). Sidekiq, backed by Redis, could not scale to that, because Redis was
+single threaded and could not overflow to disk when memory filled up.
+
+This leads to two tiers of jobs:
+
+- **Simple jobs** inherit from `RocketJob::Job` and provide the conventional "run this task in the
+  background" capability that other frameworks also offer.
+- **Batch jobs** mix in `RocketJob::Batch`, and are where the real power lies. A single logical job uploads
+  all of its input into a dynamically created MongoDB collection, which is split into *slices* that thousands
+  of workers process concurrently. Output is written back into MongoDB the same way. Because the data lives in
+  MongoDB rather than in worker memory, jobs processing very large files keep working even when the data far
+  exceeds available RAM.
+
+Two design decisions follow directly from this:
+
+- **MongoDB as the datastore.** Its atomic `find_and_modify` lets thousands of nodes claim work without
+  stepping on each other, and it transparently spills from memory to disk, which is essential for very large
+  batch jobs. Rocket Job also runs on AWS DocumentDB.
+- **Mongoid as the model layer.** Jobs are Mongoid documents, so every job field has a real, declared data
+  type with validations and type checking, instead of the untyped hash of arguments most job frameworks pass
+  around.
+
+**Backward compatibility is a priority.** It should only be broken in a major release, and ideally only after
+a deprecation path has been offered first. In practice, most forced changes come from breaking changes in
+MongoDB or Mongoid rather than from choices made here.
+
+## Architecture
+
+### Public vs internal API
+
+The public interface is small and deliberately so. Application code subclasses `RocketJob::Job`, optionally
+mixes in capability modules such as `RocketJob::Batch`, defines typed fields, and implements `#perform`.
+Queuing, downloading results, and the documented job state transitions round out the surface that is
+guaranteed to remain stable.
+
+Everything else, the plugin modules under `RocketJob::Plugins`, the slicing machinery under
+`RocketJob::Sliced`, and the runtime classes (`Supervisor`, `Server`, `WorkerPool`, `Worker`,
+`Subscriber`), is internal. It is documented here for contributors extending Rocket Job, not for callers
+using it, and may change between minor releases as long as the public job interface is preserved.
+
+### Jobs are built from plugins
+
+`RocketJob::Job` is intentionally almost empty: it composes its behavior by including a stack of modules
+(`Plugins::Document`, `Plugins::Job::Model`, `Persistence`, `Callbacks`, `Logger`, `StateMachine`, `Worker`,
+`Throttle`, ...). `Plugins::Document` is the concern that pulls in `Mongoid::Document` and pins the job to the
+`rocketjob` MongoDB client. State transitions (`queued -> running -> completed/failed/aborted/paused`) are
+driven by the `aasm` gem via the state machine plugins.
+
+Optional capabilities are themselves modules that a job opts into: `Batch`, `Cron`, `Singleton`, `Retry`,
+`ProcessingWindow`, `Transaction`, and `ThrottleDependentJobs`.
+
+### Batch jobs and slices
+
+`RocketJob::Batch` is a concern that layers slicing on top of a job. Input and output are organized into
+**categories** (`Category::Input` / `Category::Output`), each with its own serializer (plain, compressed,
+encrypted, bzip2) and collection. The data itself is stored separately from the job in the `rocketjob_slices`
+MongoDB client: `Sliced::Input` and `Sliced::Output` (both subclasses of `Sliced::Slices`) manage
+dynamically created collections of `Sliced::Slice` documents, each holding a batch of records for one worker
+to process.
+
+### Runtime: Supervisor, Server, Workers
+
+A running process is driven by the `Supervisor`, started via `bin/rocketjob` (`RocketJob::CLI`). It registers
+a `Server` document, manages a `WorkerPool` of `Worker` threads (`ThreadWorker`, or `RactorWorker` for
+Ractor-based execution), handles OS signals, and runs the listeners. Cross-process coordination (shutdown,
+pause, log-level changes) does not use a separate broker: it rides on MongoDB through `RocketJob::Event` and
+the `Subscriber` / `Subscribers::*` classes.
+
+### Class diagram
+
+```mermaid
+classDiagram
+    direction LR
+
+    %% ===== Persistence foundation =====
+    class MongoidDocument["Mongoid::Document"]
+    class Document["Plugins::Document"] {
+        <<concern>>
+        store_in client rocketjob
+        +find_and_update()
+    }
+    MongoidDocument <|.. Document : includes
+
+    %% ===== Public job interface =====
+    class Job["RocketJob::Job"] {
+        +perform()
+        +priority +description
+        +state (aasm)
+        +start! complete! fail! abort!
+    }
+    Document <|.. Job : includes
+    Job ..|> JobModel : includes
+    Job ..|> StateMachinePlugin : includes
+    Job ..|> JobWorker : includes
+    Job ..|> Throttle : includes
+
+    class JobModel["Plugins::Job::Model"]
+    class StateMachinePlugin["Plugins::StateMachine (aasm)"]
+    class JobWorker["Plugins::Job::Worker"]
+    class Throttle["Plugins::Job::Throttle"]
+
+    %% ===== Optional capability mixins =====
+    class Batch["RocketJob::Batch"] {
+        <<concern>>
+        +upload() +download()
+        input_category / output_category
+    }
+    class Cron["Plugins::Cron"]
+    class Singleton["Plugins::Singleton"]
+    class Retry["Plugins::Retry"]
+    Job <.. Batch : opt-in mixin
+    Job <.. Cron : opt-in mixin
+    Job <.. Singleton : opt-in mixin
+    Job <.. Retry : opt-in mixin
+
+    %% ===== Categories =====
+    class CategoryBase["Category::Base"] {
+        <<concern>>
+        +name +serializer +columns +format
+    }
+    class CategoryInput["Category::Input"]
+    class CategoryOutput["Category::Output"]
+    CategoryBase <|.. CategoryInput : includes
+    CategoryBase <|.. CategoryOutput : includes
+    Batch o--> "*" CategoryInput : input_categories
+    Batch o--> "*" CategoryOutput : output_categories
+
+    %% ===== Sliced storage (rocketjob_slices) =====
+    class Slices["Sliced::Slices"] {
+        +slice_size +collection_name
+        +upload download
+    }
+    class SlicedInput["Sliced::Input"]
+    class SlicedOutput["Sliced::Output"]
+    class Slice["Sliced::Slice"] {
+        Array of records + state
+    }
+    Slices <|-- SlicedInput
+    Slices <|-- SlicedOutput
+    Document <|.. Slice : includes
+    Slices o--> "*" Slice : holds
+    Batch ..> SlicedInput : input data
+    Batch ..> SlicedOutput : output data
+
+    %% ===== Runtime =====
+    class Supervisor {
+        +self.run
+        +supervise_pool
+    }
+    class Server {
+        +state (aasm)
+        +heartbeat
+    }
+    class WorkerPool {
+        +rebalance(max_workers)
+    }
+    class Worker {
+        +run +shutdown!
+    }
+    class ThreadWorker
+    class RactorWorker
+    Document <|.. Server : includes
+    Worker <|-- ThreadWorker
+    Worker <|-- RactorWorker
+    Supervisor o--> "1" Server : registers
+    Supervisor o--> "1" WorkerPool : manages
+    WorkerPool o--> "*" Worker : runs
+    Worker ..> Job : reserves & performs
+
+    %% ===== Coordination (pub/sub over MongoDB) =====
+    class Event["RocketJob::Event"]
+    class Subscriber["RocketJob::Subscriber"]
+    class SubServer["Subscribers::Server"]
+    class SubWorker["Subscribers::Worker"]
+    class SubLogger["Subscribers::Logger"]
+    Document <|.. Event : includes
+    Subscriber <|-- SubServer
+    Subscriber <|-- SubWorker
+    Subscriber <|-- SubLogger
+    Supervisor ..> Event : listens
+    Subscriber ..> Event : publishes/consumes
+```
+
+The diagram leaves out the smaller pieces (the remaining `Plugins::Job::*` modules, the serializer-specific
+slice classes such as `EncryptedSlice` and `BZip2OutputSlice`, the built-in jobs under `RocketJob::Jobs`, and
+`Subscribers::SecretConfig`) to keep it legible. They follow the same patterns as the classes shown.
+
+### Adding a job plugin
+
+A plugin is an `ActiveSupport::Concern` under `lib/rocket_job/plugins/` that a job includes to gain a
+capability. Use the `included do ... end` block to declare fields (with real Mongoid types), validations, and
+state machine callbacks. Register the class in the `autoload` list in `lib/rocketjob.rb`. If the plugin adds
+persisted fields, remember that backward compatibility matters: existing jobs in the database must still load,
+so give new fields sensible defaults rather than making them required.
 
 ## Contributor Code of Conduct
 


### PR DESCRIPTION
## Summary

Adds Claude Code project setup and an architecture guide for contributors.

- **CLAUDE.md** (new): orients future Claude Code sessions with commonly used commands (test suite, single test, rubocop, multi-version Appraisal runs), the public vs internal API boundary, the design rationale (two job tiers, why MongoDB/Mongoid, backward-compatibility policy), and the core architecture.
- **CONTRIBUTING.md**: reworked to mirror the `semantic_logger` structure, adding a **Philosophy** section, an **Architecture** overview, and a **Mermaid class diagram** of the core relationships (job plugin composition, batch slicing, the Supervisor/Server/WorkerPool/Worker runtime, and the MongoDB-backed pub/sub).

## Notes

- The Mermaid diagram was rendered locally with `mmdc` to confirm it is valid and legible.
- Targets `feature/upgrade-mongoid` because the docs reference the Mongoid 9.x appraisal gemfiles introduced on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)