### PR TITLE
Expand test coverage to 95%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,19 @@ CI runs against multiple Mongoid/Rails/Ruby combinations defined in `Appraisals`
 - `BUNDLE_GEMFILE=gemfiles/mongoid_9.1.gemfile bundle exec rake test`
 - Regenerate gemfiles after editing `Appraisals`: `bundle exec appraisal install`
 
+### Test conventions and gotchas
+
+The suite is Minitest with `minitest/spec` `describe`/`it` blocks nested inside `class FooTest < Minitest::Test`. Heavy use of `Minitest::Mock`, `.stub`, and `minitest-stub_any_instance`. Useful things learned writing tests:
+
+- **Coverage.** SimpleCov runs automatically (started in `test_helper.rb`). After a run, overall % prints to stdout and `coverage/.resultset.json` holds per-file line hits — parse it to find the least-covered files and exact missing line numbers. `coverage/index.html` is the browsable report.
+- **Shared class-level state must be reset between tests.** `Supervisor` keeps `@shutdown`/`@event` (`Concurrent::Event`) as class instance vars; `Event` keeps a class-level `@subscribers` map; `Subscriber` has `@test_mode`. Reset these in `before`/`after` or tests leak into each other. See `test/supervisor_test.rb` / `test/event_test.rb` for the reset helpers.
+- **Autoload ordering.** Constants are `autoload`ed in `lib/rocketjob.rb`. Some files trigger circular loads when referenced first in isolation — e.g. referencing `RocketJob::WorkerPool` before `RocketJob::Supervisor` fails because `worker_pool.rb` requires `supervisor/shutdown`. Fix by `require`ing the dependency (e.g. `require "rocket_job/supervisor"`) at the top of the test.
+- **Exercising persisted/legacy documents.** `Mongoid::Factory.from_db(JobClass, doc_hash)` instantiates with `new_record? == false` and fires `after_initialize` — this is how to trigger the v5→v6 batch category migration (`Batch::Categories#rocketjob_categories_migrate`) without a real legacy DB. A plain in-memory hash can hold Ruby Symbols that `test_helper.rb` would otherwise reject on BSON serialization.
+- **State without the state machine.** `Job.new(state: :completed)` sets the field directly so predicates like `completed?` work without driving an `aasm` transition. Batch sub-states are similar: `job.start; job.sub_state = :processing`.
+- **Driving real worker threads.** `ThreadWorker.new` immediately spawns a thread running `#run`; if you `kill` it before it enters `run`, the `Shutdown` exception is unhandled and `join` re-raises it — let the thread start first. A plain `Worker` is the inline/no-op strategy and is trivially testable.
+- **ActiveRecord in tests.** `upload_arel`/transaction tests use a sqlite DB via `test/config/database.yml` + an inline `ActiveRecord::Schema.define`. See `test/plugins/transaction_test.rb` and `test/sliced/input_query_test.rb`.
+- **Misc.** `DirmonEntry#pattern` is unique-validated (use distinct patterns per fixture). `Batch::Model#worker_count` caches for one second. `Category#file_name` returns an `IOStreams::Path`, not the raw string. The `job_has_properties` category-validation branch (in `UploadFileJob`/`DirmonEntry`) is only reachable for non-batch job classes, since batch jobs define the `input_categories=`/`output_categories=` setters that short-circuit it.
+
 ## Architecture
 
 ### Jobs are composed from plugin modules

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "bzip2-ffi"
 
 group :development do
   gem "rubocop"
+  gem "solargraph", require: false, platform: :ruby
 
   # Test against master
   # gem "iostreams", git: "https://github.com/rocketjob/iostreams"
@@ -33,4 +34,5 @@ group :test do
   gem "minitest-mock"
   gem "minitest-reporters"
   gem "minitest-stub_any_instance"
+  gem "simplecov", require: false
 end

--- a/gemfiles/mongoid_8.1.gemfile
+++ b/gemfiles/mongoid_8.1.gemfile
@@ -15,6 +15,7 @@ gem "jdbc-sqlite3", platform: :jruby
 
 group :development do
   gem "rubocop"
+  gem "solargraph", require: false, platform: :ruby
   gem "semantic_logger", github: "reidmorrison/semantic_logger"
 end
 
@@ -23,6 +24,7 @@ group :test do
   gem "minitest-mock"
   gem "minitest-reporters"
   gem "minitest-stub_any_instance"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/mongoid_9.0.gemfile
+++ b/gemfiles/mongoid_9.0.gemfile
@@ -15,6 +15,7 @@ gem "jdbc-sqlite3", platform: :jruby
 
 group :development do
   gem "rubocop"
+  gem "solargraph", require: false, platform: :ruby
   gem "semantic_logger", github: "reidmorrison/semantic_logger"
 end
 
@@ -23,6 +24,7 @@ group :test do
   gem "minitest-mock"
   gem "minitest-reporters"
   gem "minitest-stub_any_instance"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/mongoid_9.1.gemfile
+++ b/gemfiles/mongoid_9.1.gemfile
@@ -13,6 +13,7 @@ gem "bzip2-ffi"
 
 group :development do
   gem "rubocop"
+  gem "solargraph", require: false, platform: :ruby
   gem "semantic_logger", github: "reidmorrison/semantic_logger"
 end
 
@@ -21,6 +22,7 @@ group :test do
   gem "minitest-mock"
   gem "minitest-reporters"
   gem "minitest-stub_any_instance"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/test/batch/categories_test.rb
+++ b/test/batch/categories_test.rb
@@ -1,0 +1,192 @@
+require_relative "../test_helper"
+
+module Batch
+  class CategoriesTest < Minitest::Test
+    class CategoriesJob < RocketJob::Job
+      include RocketJob::Batch
+
+      def perform(record)
+        record
+      end
+    end
+
+    describe RocketJob::Batch::Categories do
+      before do
+        CategoriesJob.destroy_all
+      end
+
+      after do
+        CategoriesJob.destroy_all
+      end
+
+      # Builds a job from a raw (v5 era) persisted document, triggering the
+      # after_initialize migration since the document is not a new record.
+      def from_legacy(doc)
+        doc = {"_id" => BSON::ObjectId.new}.merge(doc)
+        Mongoid::Factory.from_db(CategoriesJob, doc)
+      end
+
+      describe "#input_category?" do
+        it "is true for a defined category" do
+          assert CategoriesJob.new.input_category?(:main)
+        end
+
+        it "is false for an unknown category" do
+          refute CategoriesJob.new.input_category?(:nope)
+        end
+
+        it "accepts a string name" do
+          assert CategoriesJob.new.input_category?("main")
+        end
+      end
+
+      describe "#output_category?" do
+        it "is false when no output category is defined" do
+          refute CategoriesJob.new.output_category?(:main)
+        end
+      end
+
+      describe "#input_category" do
+        it "returns a supplied Category::Input unchanged" do
+          category = RocketJob::Category::Input.new(name: :main)
+          assert_same category, CategoriesJob.new.input_category(category)
+        end
+
+        it "raises when supplied an output category" do
+          category = RocketJob::Category::Output.new(name: :main)
+          assert_raises(ArgumentError) { CategoriesJob.new.input_category(category) }
+        end
+
+        it "raises for an unknown category name" do
+          error = assert_raises(ArgumentError) { CategoriesJob.new.input_category(:missing) }
+          assert_includes error.message, "Unknown Input Category"
+        end
+      end
+
+      describe "#output_category" do
+        it "returns a supplied Category::Output unchanged" do
+          category = RocketJob::Category::Output.new(name: :main)
+          assert_same category, CategoriesJob.new.output_category(category)
+        end
+
+        it "raises when supplied an input category" do
+          category = RocketJob::Category::Input.new(name: :main)
+          assert_raises(ArgumentError) { CategoriesJob.new.output_category(category) }
+        end
+      end
+
+      describe "#merge_input_categories" do
+        it "does nothing when blank" do
+          job = CategoriesJob.new
+          job.merge_input_categories(nil)
+          assert_equal 100, job.input_category.slice_size
+        end
+
+        it "merges properties into the matching category" do
+          job = CategoriesJob.new
+          job.merge_input_categories([{"name" => "main", "slice_size" => 25}])
+          assert_equal 25, job.input_category(:main).slice_size
+        end
+
+        it "defaults the category name to main" do
+          job = CategoriesJob.new
+          job.merge_input_categories([{"slice_size" => 17}])
+          assert_equal 17, job.input_category(:main).slice_size
+        end
+      end
+
+      describe "#merge_output_categories" do
+        it "does nothing when blank" do
+          job = CategoriesJob.new
+          assert_nil job.merge_output_categories([])
+        end
+      end
+
+      describe ".from_properties" do
+        it "builds a plain job when no categories are supplied" do
+          job = CategoriesJob.from_properties("description" => "hello")
+          assert_equal "hello", job.description
+        end
+
+        it "merges supplied input category properties onto the defaults" do
+          job = CategoriesJob.from_properties(
+            "description"      => "with categories",
+            "input_categories" => [{"name" => "main", "slice_size" => 42}]
+          )
+          assert_equal "with categories", job.description
+          assert_equal 42, job.input_category(:main).slice_size
+        end
+      end
+
+      describe "#rocketjob_categories_migrate" do
+        it "leaves modern documents untouched" do
+          job = from_legacy("input_categories" => [{"name" => "main", "serializer" => "none"}])
+          assert_equal :main, job.input_category.name
+        end
+
+        it "migrates a compressed v5 job" do
+          job = from_legacy(
+            "input_categories" => [:main],
+            "compress"         => true,
+            "slice_size"       => 50
+          )
+          category = job.input_category(:main)
+          assert_equal :compress, category.serializer
+          assert_equal 50, category.slice_size
+        end
+
+        it "migrates an encrypted v5 job" do
+          job      = from_legacy("input_categories" => [:main], "encrypt" => true)
+          category = job.input_category(:main)
+          assert_equal :encrypt, category.serializer
+        end
+
+        it "migrates tabular input attributes onto the main category" do
+          job = from_legacy(
+            "input_categories"     => [:main],
+            "tabular_input_format" => :csv,
+            "tabular_input_header" => %w[name value]
+          )
+          category = job.input_category(:main)
+          assert_equal :csv, category.format
+          assert_equal %w[name value], category.columns
+        end
+
+        it "migrates a non-main input category without tabular settings" do
+          job = from_legacy(
+            "input_categories"     => %i[main other],
+            "tabular_input_format" => :csv
+          )
+          assert_equal :csv, job.input_category(:main).format
+          assert_nil job.input_category(:other).format
+        end
+
+        it "builds an output category when collect_output was set" do
+          job = from_legacy(
+            "input_categories"      => [:main],
+            "collect_output"        => true,
+            "tabular_output_format" => :csv,
+            "tabular_output_header" => %w[a b]
+          )
+          category = job.output_category(:main)
+          assert_equal :csv, category.format
+          assert_equal %w[a b], category.columns
+        end
+
+        it "does not build an output category when collect_output was false" do
+          job = from_legacy("input_categories" => [:main], "collect_output" => false)
+          assert_empty job.output_categories
+        end
+
+        it "migrates symbol output categories" do
+          job = from_legacy(
+            "input_categories"  => [:main],
+            "output_categories" => %i[main extra],
+            "collect_output"    => true
+          )
+          assert_equal %i[main extra], job.output_categories.collect(&:name)
+        end
+      end
+    end
+  end
+end

--- a/test/batch/io_test.rb
+++ b/test/batch/io_test.rb
@@ -220,6 +220,63 @@ module Batch
           end
         end
       end
+
+      describe "#upload argument validation" do
+        it "rejects supplying both an object and a block" do
+          assert_raises(ArgumentError) { job.upload(text_file) { |io| io << "x" } }
+        end
+
+        it "rejects stream options when uploading a block" do
+          assert_raises(ArgumentError) { job.upload(stream_mode: :array) { |io| io << "x" } }
+        end
+
+        it "rejects keyword arguments when uploading a Range" do
+          assert_raises(ArgumentError) { job.upload(1..10, file_name: "x.txt") }
+        end
+
+        it "rejects :columns when uploading a file" do
+          assert_raises(ArgumentError) { job.upload(text_file, columns: [:a]) }
+        end
+      end
+
+      describe "#upload_slice" do
+        it "inserts the slice and updates the record count" do
+          count = job.upload_slice(%w[a b c])
+          assert_equal 3, count
+          assert_equal 3, job.record_count
+          assert_equal 1, job.input.count
+          assert_equal %w[a b c], job.input.first.to_a
+        end
+      end
+
+      describe "deprecated upload helpers" do
+        before do
+          job.input_category.slice_size = 10
+        end
+
+        it "#upload_integer_range" do
+          count = job.upload_integer_range(1, 10)
+          assert_equal 1, count
+          assert_equal 1, job.record_count
+          assert_equal [[[1, 10]]], job.input.collect(&:to_a)
+        end
+
+        it "#upload_integer_range_in_reverse_order" do
+          count = job.upload_integer_range_in_reverse_order(1, 11)
+          assert_equal 2, count
+          assert_equal 2, job.record_count
+          assert_equal [[[2, 11]], [[1, 1]]], job.input.collect(&:to_a)
+        end
+      end
+
+      describe "#download" do
+        it "raises when the job is still processing" do
+          job.start
+          job.sub_state = :processing
+          error = assert_raises(RuntimeError) { job.download("/tmp/out.txt") }
+          assert_includes error.message, "Cannot download incomplete job"
+        end
+      end
     end
   end
 end

--- a/test/batch/model_test.rb
+++ b/test/batch/model_test.rb
@@ -16,16 +16,17 @@ module Batch
 
     describe RocketJob::Batch::Model do
       before do
-        @blah_exception = begin
+        SimpleJob.delete_all
+        @blah_exception =
           begin
             RocketJob.blah
           rescue StandardError => e
             e
           end
-        end
       end
 
       after do
+        SimpleJob.delete_all
         @job.destroy if @job && !@job.new_record?
       end
 
@@ -39,6 +40,112 @@ module Batch
         it "fails" do
           @job = SimpleJob.new
           assert_equal true, @job.fail!(@blah_exception)
+        end
+      end
+
+      describe "#percent_complete" do
+        it "is 0 when the record count has not been set" do
+          @job = SimpleJob.new
+          assert_equal 0, @job.percent_complete
+        end
+
+        it "is 100 when completed" do
+          @job = SimpleJob.new(state: :completed)
+          assert @job.completed?
+          assert_equal 100, @job.percent_complete
+        end
+
+        it "estimates progress from the remaining input slices" do
+          @job = SimpleJob.new
+          @job.upload { |records| (1..25).each { |i| records << i } }
+          @job.record_count = 100
+          # 3 slices * slice_size 10 = 30 input records still to process out of 100.
+          assert_equal 70, @job.percent_complete
+        end
+
+        it "is 0 when more input records remain than the record count" do
+          @job = SimpleJob.new
+          @job.upload { |records| (1..25).each { |i| records << i } }
+          @job.record_count = 5
+          assert_equal 0, @job.percent_complete
+        end
+      end
+
+      describe "#worker_names" do
+        it "is empty when the job is not running" do
+          @job = SimpleJob.new
+          assert_empty @job.worker_names
+        end
+
+        it "returns the job worker when in the before sub-state" do
+          @job = SimpleJob.create!(worker_name: "worker-1")
+          @job.start!
+          @job.sub_state = :before
+          assert_equal ["worker-1"], @job.worker_names
+        end
+
+        it "returns the slice workers when processing" do
+          @job = SimpleJob.create!
+          @job.upload { |records| (1..25).each { |i| records << i } }
+          @job.start!
+          @job.input.next_slice("slice-worker")
+          @job.sub_state = :processing
+          assert_equal ["slice-worker"], @job.worker_names
+        end
+      end
+
+      describe "#worker_count" do
+        it "is 0 when the job is not running" do
+          @job = SimpleJob.new
+          assert_equal 0, @job.worker_count
+        end
+
+        it "is 1 in the before sub-state" do
+          @job = SimpleJob.create!
+          @job.start!
+          @job.sub_state = :before
+          assert_equal 1, @job.worker_count
+        end
+
+        it "caches the count for one second" do
+          @job = SimpleJob.create!
+          @job.start!
+          @job.sub_state = :before
+          assert_equal 1, @job.worker_count
+          # Switching sub-state should not change the cached value within the same second.
+          @job.sub_state = :processing
+          assert_equal 1, @job.worker_count
+        end
+      end
+
+      describe "#status" do
+        it "reports queued slice counts when queued" do
+          @job = SimpleJob.create!
+          @job.upload { |records| (1..25).each { |i| records << i } }
+          status = @job.status
+          assert_equal 3, status["queued_slices"]
+        end
+
+        it "reports active, failed, and queued slices when running" do
+          @job = SimpleJob.create!
+          @job.upload { |records| (1..25).each { |i| records << i } }
+          @job.start!
+          @job.sub_state = :processing
+          status = @job.status
+          assert status.key?("active_slices")
+          assert status.key?("failed_slices")
+          assert status.key?("queued_slices")
+        end
+      end
+
+      describe "#upload_file_name" do
+        it "delegates to the input category file name" do
+          @job = SimpleJob.new
+          assert_nil @job.upload_file_name
+          @job.upload_file_name = "data.csv"
+          # Category#file_name wraps the value in an IOStreams path.
+          assert_equal "data.csv", @job.upload_file_name.to_s
+          assert_equal @job.input_category.file_name, @job.upload_file_name
         end
       end
     end

--- a/test/batch/worker_test.rb
+++ b/test/batch/worker_test.rb
@@ -198,6 +198,38 @@ module Batch
         RocketJob::Job.destroy_all
       end
 
+      describe "#work_first_slice" do
+        it "raises unless called from the before sub-state" do
+          job = SimpleJob.new
+          job.start
+          job.sub_state = :processing
+          error = assert_raises(RuntimeError) { job.work_first_slice { |record| record } }
+          assert_includes error.message, "before_batch"
+        end
+
+        it "returns 0 when no slice has arrived" do
+          job = SimpleJob.new
+          job.start
+          job.sub_state = :before
+          # Avoid the real 5 second sleeps while polling for the first slice.
+          job.stub(:sleep, nil) do
+            assert_equal(0, job.work_first_slice { |record| record })
+          end
+        end
+
+        it "processes the first slice and returns the record count" do
+          job = SimpleJob.new
+          job.upload { |records| (1..5).each { |i| records << i } }
+          job.start
+          job.sub_state = :before
+
+          processed = []
+          count     = job.work_first_slice { |record| processed << record }
+          assert_equal 5, count
+          assert_equal [1, 2, 3, 4, 5], processed
+        end
+      end
+
       describe "#work" do
         it "calls perform method" do
           job          = SimpleJob.new

--- a/test/dirmon_entry_test.rb
+++ b/test/dirmon_entry_test.rb
@@ -115,6 +115,41 @@ class DirmonEntryTest < Minitest::Test
       end
     end
 
+    describe ".get_whitelist_paths" do
+      after do
+        RocketJob::DirmonEntry.whitelist_paths.each { |path| RocketJob::DirmonEntry.delete_whitelist_path(path) }
+      end
+
+      it "returns a copy that does not mutate the original" do
+        path = RocketJob::DirmonEntry.add_whitelist_path("test/files")
+        copy = RocketJob::DirmonEntry.get_whitelist_paths
+        assert_equal [path], copy
+
+        copy << "should-not-leak"
+        refute_includes RocketJob::DirmonEntry.whitelist_paths, "should-not-leak"
+      end
+    end
+
+    describe ".counts_by_state" do
+      it "returns the number of entries in each state" do
+        dirmon_entry # enabled and persisted
+
+        failing = RocketJob::DirmonEntry.new(
+          name:              "Failing",
+          job_class_name:    "DirmonEntryTest::TestJob",
+          pattern:           "test/other/**",
+          properties:        {user_id: 341},
+          archive_directory: archive_directory
+        )
+        failing.enable!
+        failing.fail!("worker:1", "boom")
+
+        counts = RocketJob::DirmonEntry.counts_by_state
+        assert_equal 1, counts[:enabled]
+        assert_equal 1, counts[:failed]
+      end
+    end
+
     describe ".add_whitelist_path" do
       after do
         RocketJob::DirmonEntry.whitelist_paths.each { |path| RocketJob::DirmonEntry.delete_whitelist_path(path) }
@@ -205,6 +240,18 @@ class DirmonEntryTest < Minitest::Test
           dirmon_entry.properties = {blah: 123}
           refute dirmon_entry.valid?
           assert_equal ["Unknown Property: Attempted to set a value for :blah which is not allowed on the job DirmonEntryTest::TestJob"], dirmon_entry.errors[:properties], dirmon_entry.errors.messages.ai
+        end
+
+        it "allows known category properties" do
+          dirmon_entry.properties = {output_categories: [{name: "main"}]}
+          assert dirmon_entry.valid?, dirmon_entry.errors.messages.ai
+        end
+
+        it "rejects unknown category properties" do
+          dirmon_entry.properties = {output_categories: [{not_a_category_field: 1}]}
+          refute dirmon_entry.valid?
+          assert(dirmon_entry.errors[:properties].any? { |m| m.include?("not_a_category_field") },
+                 dirmon_entry.errors.messages.ai)
         end
       end
     end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -1,0 +1,187 @@
+require_relative "test_helper"
+
+# Subscriber that records the actions dispatched to it for a single named event.
+class EventTestRecorder
+  include RocketJob::Subscriber
+
+  self.event_name = "EventTestRecorder"
+
+  attr_reader :received
+
+  def hello(message: nil)
+    @received = [:hello, message]
+  end
+
+  def boom
+    raise "boom"
+  end
+end
+
+# Subscriber that listens to every published event.
+class EventTestAllEvents
+  include RocketJob::Subscriber
+
+  self.event_name = RocketJob::Event::ALL_EVENTS
+
+  attr_reader :events
+
+  def initialize
+    @events = []
+  end
+
+  def process_event(name, action, parameters)
+    @events << [name, action, parameters]
+  end
+end
+
+class EventTest < Minitest::Test
+  describe RocketJob::Event do
+    before do
+      reset_subscribers
+    end
+
+    after do
+      reset_subscribers
+    end
+
+    # The subscriber registry is class level state shared across the process,
+    # so reset it between tests to keep them isolated.
+    def reset_subscribers
+      empty = Concurrent::Map.new { Concurrent::Array.new }
+      RocketJob::Event.instance_variable_set(:@subscribers, empty)
+    end
+
+    describe "validations" do
+      it "requires a name" do
+        event = RocketJob::Event.new
+        refute event.valid?
+        assert event.errors[:name].present?
+      end
+
+      it "is valid with a name" do
+        assert RocketJob::Event.new(name: "/rocket_job/server").valid?
+      end
+    end
+
+    describe ".subscribe" do
+      it "registers a subscriber and returns its object id as a handle" do
+        subscriber = EventTestRecorder.new
+        handle     = RocketJob::Event.subscribe(subscriber)
+        assert_equal subscriber.object_id, handle
+      end
+
+      it "yields the subscriber and unsubscribes when the block completes" do
+        subscriber = EventTestRecorder.new
+        yielded    = nil
+
+        RocketJob::Event.subscribe(subscriber) do |s|
+          yielded = s
+          registered = RocketJob::Event.instance_variable_get(:@subscribers)["EventTestRecorder"]
+          assert_includes registered, subscriber
+        end
+
+        assert_equal subscriber, yielded
+        registered = RocketJob::Event.instance_variable_get(:@subscribers)["EventTestRecorder"]
+        refute_includes registered, subscriber
+      end
+
+      it "unsubscribes even when the block raises" do
+        subscriber = EventTestRecorder.new
+        assert_raises(RuntimeError) do
+          RocketJob::Event.subscribe(subscriber) { raise "kaboom" }
+        end
+        registered = RocketJob::Event.instance_variable_get(:@subscribers)["EventTestRecorder"]
+        refute_includes registered, subscriber
+      end
+    end
+
+    describe ".unsubscribe" do
+      it "removes only the subscriber matching the handle" do
+        keep   = EventTestRecorder.new
+        remove = EventTestRecorder.new
+        RocketJob::Event.subscribe(keep)
+        handle = RocketJob::Event.subscribe(remove)
+
+        RocketJob::Event.unsubscribe(handle)
+
+        registered = RocketJob::Event.instance_variable_get(:@subscribers)["EventTestRecorder"]
+        assert_includes registered, keep
+        refute_includes registered, remove
+      end
+    end
+
+    describe ".process_event" do
+      it "dispatches the action to a subscriber registered for the event name" do
+        subscriber = EventTestRecorder.new
+        RocketJob::Event.subscribe(subscriber)
+
+        event = RocketJob::Event.new(name: "EventTestRecorder", action: :hello, parameters: {"message" => "hi"})
+        RocketJob::Event.process_event(event)
+
+        assert_equal [:hello, "hi"], subscriber.received
+      end
+
+      it "notifies all-events subscribers via process_event" do
+        listener = EventTestAllEvents.new
+        RocketJob::Event.subscribe(listener)
+
+        event = RocketJob::Event.new(name: "EventTestRecorder", action: :hello, parameters: {"message" => "hi"})
+        RocketJob::Event.process_event(event)
+
+        assert_equal [["EventTestRecorder", :hello, {"message" => "hi"}]], listener.events
+      end
+
+      it "does nothing when there are no subscribers for the event name" do
+        event = RocketJob::Event.new(name: "Nobody", action: :hello)
+        # Should not raise.
+        assert_nil RocketJob::Event.process_event(event)
+      end
+
+      it "rescues exceptions raised by a subscriber" do
+        subscriber = EventTestRecorder.new
+        RocketJob::Event.subscribe(subscriber)
+
+        event = RocketJob::Event.new(name: "EventTestRecorder", action: :boom)
+        # process_action swallows the error, so process_event completes cleanly.
+        RocketJob::Event.process_event(event)
+      end
+    end
+
+    describe "capped collection" do
+      before do
+        RocketJob::Event.collection.drop
+      end
+
+      after do
+        RocketJob::Event.collection.drop
+      end
+
+      describe ".collection_exists?" do
+        it "is false before the collection is created" do
+          refute RocketJob::Event.collection_exists?
+        end
+
+        it "is true once the collection is created" do
+          RocketJob::Event.create_capped_collection
+          assert RocketJob::Event.collection_exists?
+        end
+      end
+
+      describe ".create_capped_collection" do
+        it "creates a capped collection when none exists" do
+          RocketJob::Event.create_capped_collection
+          assert RocketJob::Event.collection.capped?
+        end
+
+        it "converts an existing non-capped collection to capped" do
+          # Create a plain, non-capped collection first.
+          RocketJob::Event.create!(name: "/rocket_job/server", action: :seed)
+          refute RocketJob::Event.collection.capped?
+
+          RocketJob::Event.create_capped_collection
+          assert RocketJob::Event.collection.capped?
+        end
+      end
+    end
+  end
+end

--- a/test/jobs/upload_file_job_test.rb
+++ b/test/jobs/upload_file_job_test.rb
@@ -33,6 +33,22 @@ module Jobs
       end
     end
 
+    # Responds to upload_file_name= but not #upload.
+    class UploadNameJob < RocketJob::Job
+      field :upload_file_name, type: String
+
+      def perform
+      end
+    end
+
+    # Responds to full_file_name= but not #upload or upload_file_name=.
+    class FullNameJob < RocketJob::Job
+      field :full_file_name, type: String
+
+      def perform
+      end
+    end
+
     describe RocketJob::Jobs::UploadFileJob do
       before do
         RocketJob::Job.delete_all
@@ -97,6 +113,26 @@ module Jobs
           message = "Jobs::UploadFileJobTest::BadJob must implement any one of: :upload :upload_file_name= :full_file_name= instance methods"
           assert_includes job.errors.messages[:job_class_name], message
         end
+
+        it "validates the job class inherits from RocketJob::Job" do
+          job.job_class_name = "Hash"
+          refute job.valid?
+          assert_includes job.errors.messages[:job_class_name],
+                          "Model Hash must be defined and inherit from RocketJob::Job"
+        end
+
+        it "is valid when the job class name cannot be resolved" do
+          # job_class rescues NameError and returns nil, so the class based
+          # validations are skipped.
+          job.job_class_name = "No::Such::Constant"
+          assert job.valid?, job.errors.messages
+        end
+
+        it "rejects unknown top level properties" do
+          job.properties = {"does_not_exist" => 1}
+          refute job.valid?
+          assert(job.errors.messages[:properties].any? { |m| m.include?("does_not_exist") })
+        end
       end
 
       describe "#perform" do
@@ -137,6 +173,31 @@ module Jobs
           assert_equal :csv, created_job.input_category.format
           assert_equal :csv, created_job.output_category.format
           assert_equal %w[first_name last_name], created_job.output_category.columns
+        end
+
+        it "assigns the supplied job_id to the downstream job" do
+          id         = BSON::ObjectId.new
+          job.job_id = id
+          job.perform_now
+
+          assert created_job = UploadFileJobTest::TestJob.first
+          assert_equal id, created_job.id
+        end
+
+        it "assigns upload_file_name when the job has no #upload method" do
+          job.job_class_name = UploadFileJobTest::UploadNameJob.name
+          job.perform_now
+
+          assert created_job = UploadFileJobTest::UploadNameJob.first
+          assert_equal __FILE__, created_job.upload_file_name
+        end
+
+        it "assigns full_file_name when that is the only writer available" do
+          job.job_class_name = UploadFileJobTest::FullNameJob.name
+          job.perform_now
+
+          assert created_job = UploadFileJobTest::FullNameJob.first
+          assert_equal __FILE__, created_job.full_file_name
         end
       end
     end

--- a/test/plugins/document_test.rb
+++ b/test/plugins/document_test.rb
@@ -1,0 +1,72 @@
+require_relative "../test_helper"
+
+module Plugins
+  class DocumentTest < Minitest::Test
+    class DocumentJob < RocketJob::Job
+      field :data, type: Hash
+
+      def perform
+        data
+      end
+    end
+
+    describe RocketJob::Plugins::Document do
+      before do
+        RocketJob::Job.destroy_all
+      end
+
+      after do
+        RocketJob::Job.destroy_all
+      end
+
+      describe ".first / .last" do
+        it "returns nil when there are no documents" do
+          assert_nil DocumentJob.first
+          assert_nil DocumentJob.last
+        end
+
+        it "orders by _id ascending and descending" do
+          first_job = DocumentJob.create!(description: "first")
+          last_job  = DocumentJob.create!(description: "last")
+
+          assert_equal first_job.id, DocumentJob.first.id
+          assert_equal last_job.id, DocumentJob.last.id
+        end
+      end
+
+      describe "#find_and_update" do
+        it "applies changes and returns the reloaded document" do
+          job = DocumentJob.create!(description: "before")
+
+          result = job.send(:find_and_update, "description" => "after")
+
+          assert_same job, result
+          assert_equal "after", job.description
+          # The change is persisted in the database.
+          assert_equal "after", DocumentJob.find(job.id).description
+        end
+
+        it "loads concurrent changes made on the server" do
+          job = DocumentJob.create!(description: "original", priority: 10)
+
+          # Simulate another process updating a different attribute.
+          DocumentJob.collection.find(_id: job.id).update_one("$set" => {"priority" => 99})
+
+          job.send(:find_and_update, "description" => "updated")
+
+          assert_equal "updated", job.description
+          assert_equal 99, job.priority
+        end
+
+        it "raises DocumentNotFound when the document no longer exists" do
+          job = DocumentJob.create!(description: "gone")
+          job.destroy
+
+          assert_raises(Mongoid::Errors::DocumentNotFound) do
+            job.send(:find_and_update, "description" => "nope")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/plugins/job/model_test.rb
+++ b/test/plugins/job/model_test.rb
@@ -22,6 +22,149 @@ module Plugins
           RocketJob::Job.destroy_all
         end
 
+        describe ".underscore_name" do
+          it "derives the name from the class, dropping the Job suffix" do
+            assert_equal "plugins/job/model_test/simple", SimpleJob.underscore_name
+          end
+
+          it "can be overridden" do
+            SimpleJob.underscore_name = "custom_name"
+            assert_equal "custom_name", SimpleJob.underscore_name
+          ensure
+            SimpleJob.instance_variable_set(:@underscore_name, nil)
+          end
+        end
+
+        describe ".human_name" do
+          it "derives a human readable name" do
+            assert_equal "Plugins/Job/Model Test/Simple", SimpleJob.human_name
+          end
+
+          it "can be overridden" do
+            SimpleJob.human_name = "Custom Human"
+            assert_equal "Custom Human", SimpleJob.human_name
+          ensure
+            SimpleJob.instance_variable_set(:@human_name, nil)
+          end
+        end
+
+        describe ".collective_name" do
+          it "derives a pluralized underscored name" do
+            assert_equal "plugins/job/model_test/simples", SimpleJob.collective_name
+          end
+
+          it "can be overridden" do
+            SimpleJob.collective_name = "customs"
+            assert_equal "customs", SimpleJob.collective_name
+          ensure
+            SimpleJob.instance_variable_set(:@collective_name, nil)
+          end
+        end
+
+        describe "#seconds and #duration" do
+          it "measures time in the queue when not yet started" do
+            job = SimpleJob.new(created_at: 10.seconds.ago)
+            assert job.seconds >= 10
+            assert_kind_of String, job.duration
+          end
+
+          it "measures elapsed run time while running" do
+            job = SimpleJob.new(started_at: 5.seconds.ago)
+            assert job.seconds >= 5
+          end
+
+          it "measures total run time once completed" do
+            job = SimpleJob.new(started_at: 20.seconds.ago, completed_at: 5.seconds.ago)
+            assert_in_delta 15, job.seconds, 1
+          end
+        end
+
+        describe "#expired?" do
+          it "is false when there is no expiry" do
+            refute SimpleJob.new.expired?
+          end
+
+          it "is true once the expiry has passed" do
+            assert SimpleJob.new(expires_at: 1.minute.ago).expired?
+          end
+
+          it "is false when the expiry is in the future" do
+            refute SimpleJob.new(expires_at: 1.minute.from_now).expired?
+          end
+        end
+
+        describe "#sleeping? #worker_count #worker_names" do
+          it "reports no workers for a queued job" do
+            job = SimpleJob.new
+            assert_equal 0, job.worker_count
+            assert_empty job.worker_names
+          end
+
+          it "reports a worker for a running, assigned job" do
+            job = SimpleJob.new(worker_name: "server:1")
+            job.start
+            assert_equal 1, job.worker_count
+            assert_equal ["server:1"], job.worker_names
+            refute job.sleeping?
+          end
+
+          it "is sleeping when running without an assigned worker" do
+            job = SimpleJob.new
+            job.start
+            assert job.sleeping?
+          end
+        end
+
+        describe "#run_now!" do
+          it "clears run_at so the job runs immediately" do
+            job = SimpleJob.create!(run_at: 1.day.from_now)
+            job.run_now!
+            assert_nil job.reload.run_at
+          end
+
+          it "does nothing when run_at is already nil" do
+            job = SimpleJob.create!
+            job.run_now!
+            assert_nil job.reload.run_at
+          end
+        end
+
+        describe "#scheduled_at" do
+          it "returns run_at when set" do
+            at  = 1.day.from_now
+            job = SimpleJob.new(run_at: at)
+            assert_equal at.to_i, job.scheduled_at.to_i
+          end
+
+          it "falls back to created_at" do
+            job = SimpleJob.create!
+            assert_equal job.created_at, job.scheduled_at
+          end
+        end
+
+        describe "#worker_on_server?" do
+          it "is false when no worker is assigned" do
+            refute SimpleJob.new.worker_on_server?("server:1")
+          end
+
+          it "matches the server name prefix of the worker name" do
+            job = SimpleJob.new(worker_name: "server:1:thread:2")
+            assert job.worker_on_server?("server:1")
+            refute job.worker_on_server?("other")
+          end
+        end
+
+        describe "#status" do
+          it "stringifies times and ids for a queued job" do
+            job    = SimpleJob.create!
+            status = job.status
+            assert_equal :queued, status["state"]
+            # The BSON::ObjectId and Time values are converted to Strings.
+            assert_kind_of String, status["_id"]
+            assert_kind_of String, status["created_at"]
+          end
+        end
+
         describe "#scheduled?" do
           it "returns true if job is queued to run in the future" do
             job = SimpleJob.new(run_at: 1.day.from_now)

--- a/test/plugins/job/persistence_test.rb
+++ b/test/plugins/job/persistence_test.rb
@@ -86,6 +86,95 @@ module Plugins
             assert_equal 1, counts[:queued_now]
             assert_equal 1, counts[:scheduled]
           end
+
+          it "treats all queued jobs as queued_now when none are scheduled" do
+            @job.save!
+            @job2  = PersistJob.create!(data: {key: "value"})
+            counts = RocketJob::Job.counts_by_state
+            assert_equal 2, counts[:queued]
+            assert_equal 2, counts[:queued_now]
+            refute counts.key?(:scheduled)
+          end
+
+          it "returns an empty hash when there are no jobs" do
+            assert_equal({}, RocketJob::Job.counts_by_state)
+          end
+        end
+
+        describe "#create_restart!" do
+          it "creates a new queued instance copying copy_on_restart attributes" do
+            @job.save!
+            assert_equal 1, RocketJob::Job.count
+            @job.create_restart!
+            assert_equal 2, RocketJob::Job.count
+            @job2 = RocketJob::Job.where(:id.ne => @job.id).first
+            assert @job2
+            assert_equal @description, @job2.description
+            assert_equal 53, @job2.priority
+            assert_equal false, @job2.destroy_on_complete
+            assert @job2.queued?
+            # `data` is not a copy_on_restart attribute, so it is not carried over.
+            assert_nil @job2.data
+          end
+
+          it "applies overrides to the new instance" do
+            @job.save!
+            @job.create_restart!(priority: 11, description: "Restarted")
+            @job2 = RocketJob::Job.where(:id.ne => @job.id).first
+            assert_equal 11, @job2.priority
+            assert_equal "Restarted", @job2.description
+          end
+
+          it "does not create a new instance when the job has expired" do
+            @job.expires_at = 1.day.ago
+            @job.save!
+            assert_equal 1, RocketJob::Job.count
+            assert_nil @job.create_restart!
+            assert_equal 1, RocketJob::Job.count
+          end
+        end
+
+        describe "#reload" do
+          it "marks an incomplete job complete when destroyed and destroy_on_complete is set" do
+            @job2 = PersistJob.create!(data: {key: "value"}, destroy_on_complete: true)
+            refute @job2.completed?
+            # Simulate the job being destroyed from the database by another process.
+            RocketJob::Job.where(id: @job2.id).delete_all
+            @job2.reload
+            assert @job2.completed?
+            assert @job2.completed_at
+          end
+        end
+
+        describe "#save_with_retry!" do
+          it "persists the job and returns true" do
+            assert_equal true, @job.save_with_retry!
+            refute @job.new_record?
+            assert RocketJob::Job.where(id: @job.id).exists?
+          end
+
+          it "retries on failure and succeeds once save returns true" do
+            calls = 0
+            # Fail the first two attempts, then succeed on the third.
+            saver = lambda do |*|
+              calls += 1
+              calls >= 3
+            end
+            @job.stub(:save, saver) do
+              assert @job.save_with_retry!(5, 0)
+            end
+            assert_equal 3, calls
+          end
+
+          it "raises via save! once the retry limit is exhausted" do
+            # `save` never succeeds, so the loop exhausts its retries and the
+            # final `save!` surfaces the failure.
+            @job.stub(:save, false) do
+              assert_raises(::Mongoid::Errors::Callback) do
+                @job.save_with_retry!(2, 0)
+              end
+            end
+          end
         end
       end
     end

--- a/test/plugins/job/worker_test.rb
+++ b/test/plugins/job/worker_test.rb
@@ -30,6 +30,22 @@ module Plugins
         end
       end
 
+      class FailingJob < RocketJob::Job
+        self.destroy_on_complete = false
+
+        def perform
+          raise "Job failed"
+        end
+      end
+
+      class ValidationJob < RocketJob::Job
+        field :name, type: String
+        validates_presence_of :name
+
+        def perform
+        end
+      end
+
       describe RocketJob::Plugins::Job::Worker do
         before do
           RocketJob::Job.delete_all
@@ -79,6 +95,22 @@ module Plugins
             end
             assert_equal false, logged
           end
+
+          it "raises a validation error for an invalid job" do
+            @job = ValidationJob.new
+            assert_raises Mongoid::Errors::Validations do
+              @job.perform_now
+            end
+            refute @job.completed?
+          end
+
+          it "re-raises exceptions from perform" do
+            @job = FailingJob.new
+            error = assert_raises RuntimeError do
+              @job.perform_now
+            end
+            assert_equal "Job failed", error.message
+          end
         end
 
         describe ".perform_now" do
@@ -86,6 +118,93 @@ module Plugins
             @job = SumJob.perform_now(first: 1, second: 5)
             assert_equal true, @job.completed?
             assert_equal 6, @job.result
+          end
+        end
+
+        describe "#perform" do
+          it "raises NotImplementedError when not overridden" do
+            assert_raises NotImplementedError do
+              RocketJob::Job.new.perform
+            end
+          end
+        end
+
+        describe "#rocket_job_work" do
+          it "raises an ArgumentError when the job is not running" do
+            @job = SumJob.new(first: 1, second: 2)
+            assert @job.queued?
+            error = assert_raises ArgumentError do
+              @job.rocket_job_work(RocketJob::Worker.new)
+            end
+            assert_includes error.message, "must be started"
+          end
+
+          it "fails the job and persists it when perform raises" do
+            @job = FailingJob.create!
+            @job.start!
+            refute @job.rocket_job_work(RocketJob::Worker.new)
+            @job.reload
+            assert @job.failed?, @job.state
+            assert_equal "Job failed", @job.exception.message
+          end
+
+          it "completes a persisted job" do
+            @job = SumJob.create!(first: 3, second: 4)
+            @job.start!
+            refute @job.rocket_job_work(RocketJob::Worker.new)
+            @job.reload
+            assert @job.completed?, @job.state
+            assert_equal 7, @job.result
+          end
+        end
+
+        describe "#fail_on_exception!" do
+          it "fails and saves the job when the block raises" do
+            @job = SumJob.create!(first: 1, second: 2, worker_name: "worker:123")
+            @job.start!
+            @job.fail_on_exception! do
+              raise "boom"
+            end
+            assert @job.failed?, @job.state
+            @job.reload
+            assert @job.failed?, @job.state
+            assert_equal "boom", @job.exception.message
+            assert_equal "worker:123", @job.exception.worker_name
+          end
+
+          it "re-raises the exception when requested" do
+            @job = SumJob.create!(first: 1, second: 2)
+            @job.start!
+            assert_raises RuntimeError do
+              @job.fail_on_exception!(true) do
+                raise "boom"
+              end
+            end
+            assert @job.failed?, @job.state
+          end
+
+          it "does not transition an already failed job but records the exception" do
+            @job = SumJob.create!(first: 1, second: 2, worker_name: "worker:123")
+            @job.start!
+            @job.fail!("worker:123", "first failure")
+            assert @job.failed?, @job.state
+
+            @job.fail_on_exception! do
+              raise "second failure"
+            end
+            assert @job.failed?, @job.state
+            assert_equal "second failure", @job.exception.message
+          end
+
+          it "does nothing when the block does not raise" do
+            @job = SumJob.create!(first: 1, second: 2)
+            @job.start!
+            ran = false
+            @job.fail_on_exception! do
+              ran = true
+            end
+            assert ran
+            refute @job.failed?
           end
         end
 
@@ -105,6 +224,18 @@ module Plugins
             assert_equal job.started_at, active_worker.started_at
             assert active_worker.duration_s
             assert active_worker.duration
+          end
+
+          it "returns the worker when it runs on the named server" do
+            @job = SumJob.new(worker_name: "worker:123")
+            @job.start!
+            assert_equal 1, @job.rocket_job_active_workers("worker").size
+          end
+
+          it "returns empty when the worker is not on the named server" do
+            @job = SumJob.new(worker_name: "worker:123")
+            @job.start!
+            assert_equal [], @job.rocket_job_active_workers("other_server")
           end
         end
       end

--- a/test/rocket_job_test.rb
+++ b/test/rocket_job_test.rb
@@ -1,0 +1,65 @@
+require_relative "test_helper"
+
+class RocketJobTest < Minitest::Test
+  describe RocketJob do
+    describe ".seconds_as_duration" do
+      it "returns nil when seconds is nil" do
+        assert_nil RocketJob.seconds_as_duration(nil)
+      end
+
+      it "formats sub-millisecond durations with three decimals" do
+        assert_equal "5.000ms", RocketJob.seconds_as_duration(0.005)
+      end
+
+      it "formats larger millisecond durations with one decimal" do
+        assert_equal "50.0ms", RocketJob.seconds_as_duration(0.05)
+      end
+
+      it "formats durations of at least one second" do
+        assert_equal "5.000s", RocketJob.seconds_as_duration(5.0)
+      end
+
+      it "formats durations of at least one minute" do
+        assert_equal "1m 30s", RocketJob.seconds_as_duration(90.0)
+      end
+
+      it "formats durations of at least one hour" do
+        assert_equal "1h 1m", RocketJob.seconds_as_duration(3661.0)
+      end
+
+      it "formats durations of at least one day" do
+        # 1 day + 1 hour + 1 minute + 1 second
+        assert_equal "1d 1h 1m", RocketJob.seconds_as_duration(90_061.0)
+      end
+    end
+
+    describe "process flags" do
+      before do
+        @server = RocketJob.instance_variable_get(:@server)
+        @rails  = RocketJob.instance_variable_get(:@rails)
+      end
+
+      after do
+        RocketJob.instance_variable_set(:@server, @server)
+        RocketJob.instance_variable_set(:@rails, @rails)
+      end
+
+      it "tracks the server flag" do
+        RocketJob.instance_variable_set(:@server, false)
+        refute RocketJob.server?
+        RocketJob.server!
+        assert RocketJob.server?
+      end
+
+      it "tracks the rails flag and standalone is its inverse" do
+        RocketJob.instance_variable_set(:@rails, false)
+        refute RocketJob.rails?
+        assert RocketJob.standalone?
+
+        RocketJob.rails!
+        assert RocketJob.rails?
+        refute RocketJob.standalone?
+      end
+    end
+  end
+end

--- a/test/server/model_test.rb
+++ b/test/server/model_test.rb
@@ -1,0 +1,82 @@
+require_relative "../test_helper"
+
+module Server
+  class ModelTest < Minitest::Test
+    describe RocketJob::Server::Model do
+      before do
+        RocketJob::Server.destroy_all
+      end
+
+      after do
+        RocketJob::Server.destroy_all
+      end
+
+      # Builds a persisted server in the supplied state, optionally with a stale heartbeat.
+      def create_server(name:, state:, heartbeat_at: Time.now)
+        server           = RocketJob::Server.new(name: name, state: state)
+        server.heartbeat = RocketJob::Heartbeat.new(updated_at: heartbeat_at) if heartbeat_at
+        server.save!
+        server
+      end
+
+      describe ".counts_by_state" do
+        it "is empty when there are no servers" do
+          assert_equal({}, RocketJob::Server.counts_by_state)
+        end
+
+        it "returns the number of servers in each state" do
+          create_server(name: "a", state: :running)
+          create_server(name: "b", state: :running)
+          create_server(name: "c", state: :paused)
+
+          counts = RocketJob::Server.counts_by_state
+          assert_equal 2, counts[:running]
+          assert_equal 1, counts[:paused]
+        end
+      end
+
+      describe "#zombie?" do
+        it "is false for a server that is not running, stopping, or paused" do
+          server = create_server(name: "starting", state: :starting)
+          refute server.zombie?
+        end
+
+        it "is true for a running server with no heartbeat" do
+          server = create_server(name: "no-beat", state: :running, heartbeat_at: nil)
+          assert server.zombie?
+        end
+
+        it "is true for a running server whose heartbeat is stale" do
+          server = create_server(name: "stale", state: :running, heartbeat_at: 5.minutes.ago)
+          assert server.zombie?
+        end
+
+        it "is false for a running server with a recent heartbeat" do
+          server = create_server(name: "fresh", state: :running, heartbeat_at: Time.now)
+          refute server.zombie?
+        end
+      end
+
+      describe ".zombies" do
+        it "returns only servers with stale or missing heartbeats" do
+          create_server(name: "alive", state: :running, heartbeat_at: Time.now)
+          stale = create_server(name: "stale", state: :running, heartbeat_at: 5.minutes.ago)
+
+          zombie_names = RocketJob::Server.zombies.collect(&:name)
+          assert_includes zombie_names, stale.name
+          refute_includes zombie_names, "alive"
+        end
+      end
+
+      describe ".destroy_zombies" do
+        it "destroys zombie servers and returns the count" do
+          create_server(name: "alive", state: :running, heartbeat_at: Time.now)
+          create_server(name: "stale", state: :running, heartbeat_at: 5.minutes.ago)
+
+          assert_equal 1, RocketJob::Server.destroy_zombies
+          assert_equal ["alive"], RocketJob::Server.all.collect(&:name)
+        end
+      end
+    end
+  end
+end

--- a/test/sliced/input_query_test.rb
+++ b/test/sliced/input_query_test.rb
@@ -1,0 +1,109 @@
+require_relative "../test_helper"
+require "active_record"
+
+ActiveRecord::Base.configurations = YAML.safe_load(ERB.new(File.read("test/config/database.yml")).result)
+ActiveRecord::Base.establish_connection(:test)
+
+ActiveRecord::Schema.define version: 0 do
+  create_table :input_query_people, force: true do |t|
+    t.string :name
+    t.integer :age
+  end
+end
+
+# ActiveRecord source for upload_arel.
+class InputQueryPerson < ActiveRecord::Base
+end
+
+# Mongoid source for upload_mongo_query.
+class InputQueryDoc
+  include Mongoid::Document
+
+  store_in collection: "input_query_docs"
+
+  field :name, type: String
+  field :age, type: Integer
+end
+
+module Sliced
+  class InputQueryTest < Minitest::Test
+    describe RocketJob::Sliced::Input do
+      let(:collection_name) { :"rocket_job.slices.query_test" }
+
+      let :input do
+        RocketJob::Sliced::Input.new(collection_name: collection_name, slice_size: 100)
+      end
+
+      before do
+        input.delete_all
+        InputQueryPerson.delete_all
+        InputQueryDoc.delete_all
+      end
+
+      after do
+        input.drop
+        InputQueryPerson.delete_all
+        InputQueryDoc.delete_all
+      end
+
+      describe "#upload_arel" do
+        before do
+          @alice = InputQueryPerson.create!(name: "Alice", age: 30)
+          @bob   = InputQueryPerson.create!(name: "Bob", age: 40)
+        end
+
+        it "uploads the id of each record by default" do
+          count = input.upload_arel(InputQueryPerson.all)
+          assert_equal 2, count
+          assert_equal [@alice.id, @bob.id].sort, input.collect(&:to_a).flatten.sort
+        end
+
+        it "uploads a single named column" do
+          count = input.upload_arel(InputQueryPerson.all, columns: [:name])
+          assert_equal 2, count
+          assert_equal %w[Alice Bob], input.collect(&:to_a).flatten.sort
+        end
+
+        it "uploads multiple columns as arrays" do
+          input.upload_arel(InputQueryPerson.all, columns: %i[name age])
+          rows = input.collect(&:to_a).flatten(1).sort
+          assert_equal [["Alice", 30], ["Bob", 40]], rows
+        end
+
+        it "honors a supplied block" do
+          input.upload_arel(InputQueryPerson.all) { |model| model.name.upcase }
+          assert_equal %w[ALICE BOB], input.collect(&:to_a).flatten.sort
+        end
+      end
+
+      describe "#upload_mongo_query" do
+        before do
+          @alice = InputQueryDoc.create!(name: "Alice", age: 30)
+          @bob   = InputQueryDoc.create!(name: "Bob", age: 40)
+        end
+
+        it "uploads the _id of each document by default" do
+          count = input.upload_mongo_query(InputQueryDoc.all)
+          assert_equal 2, count
+          assert_equal [@alice.id, @bob.id].sort, input.collect(&:to_a).flatten.sort
+        end
+
+        it "uploads a single named column" do
+          input.upload_mongo_query(InputQueryDoc.all, columns: [:name])
+          assert_equal %w[Alice Bob], input.collect(&:to_a).flatten.sort
+        end
+
+        it "uploads multiple columns as arrays" do
+          input.upload_mongo_query(InputQueryDoc.all, columns: %i[name age])
+          rows = input.collect(&:to_a).flatten(1).sort
+          assert_equal [["Alice", 30], ["Bob", 40]], rows
+        end
+
+        it "honors a supplied block" do
+          input.upload_mongo_query(InputQueryDoc.all) { |document| document["name"].downcase }
+          assert_equal %w[alice bob], input.collect(&:to_a).flatten.sort
+        end
+      end
+    end
+  end
+end

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -1,0 +1,149 @@
+require_relative "test_helper"
+
+# Test subscriber that records the actions it receives so the dispatch
+# logic in RocketJob::Subscriber can be verified.
+class SubscriberTestSubscriber
+  include RocketJob::Subscriber
+
+  attr_reader :received
+
+  def hello
+    @received = [:hello]
+  end
+
+  def show(message:)
+    @received = [:show, message]
+  end
+
+  def show_default(message: "Hello World")
+    @received = [:show_default, message]
+  end
+
+  def boom(message:)
+    raise "boom #{message}"
+  end
+end
+
+# Subscriber that listens to every event published.
+class SubscriberTestAllEvents
+  include RocketJob::Subscriber
+
+  self.event_name = RocketJob::Event::ALL_EVENTS
+
+  def hello
+    @received = true
+  end
+end
+
+class SubscriberTest < Minitest::Test
+  describe RocketJob::Subscriber do
+    let(:subscriber) { SubscriberTestSubscriber.new }
+
+    describe ".event_name" do
+      it "defaults to the class name" do
+        assert_equal "SubscriberTestSubscriber", SubscriberTestSubscriber.event_name
+      end
+
+      it "can be overridden to listen to all events" do
+        assert_equal RocketJob::Event::ALL_EVENTS, SubscriberTestAllEvents.event_name
+      end
+    end
+
+    describe ".test_mode!" do
+      after do
+        RocketJob::Subscriber.instance_variable_set(:@test_mode, false)
+      end
+
+      it "toggles test mode" do
+        refute RocketJob::Subscriber.test_mode?
+        RocketJob::Subscriber.test_mode!
+        assert RocketJob::Subscriber.test_mode?
+      end
+    end
+
+    describe ".publish" do
+      it "raises ArgumentError for an unknown action" do
+        error = assert_raises(ArgumentError) do
+          SubscriberTestSubscriber.publish(:unknown_action)
+        end
+        assert_includes error.message, "unknown_action"
+      end
+
+      it "raises NotImplementedError when publishing to an all events subscriber" do
+        assert_raises(NotImplementedError) do
+          SubscriberTestAllEvents.publish(:hello)
+        end
+      end
+
+      it "dispatches directly to subscribers in test mode" do
+        RocketJob::Subscriber.test_mode!
+        begin
+          SubscriberTestSubscriber.subscribe do |instance|
+            SubscriberTestSubscriber.publish(:show, message: "from publish")
+            assert_equal [:show, "from publish"], instance.received
+          end
+        ensure
+          RocketJob::Subscriber.instance_variable_set(:@test_mode, false)
+        end
+      end
+    end
+
+    describe ".subscribe" do
+      it "registers the subscriber and returns a handle" do
+        handle = SubscriberTestSubscriber.subscribe
+        assert_kind_of Integer, handle
+        RocketJob::Event.unsubscribe(handle)
+      end
+
+      it "yields the subscriber instance and unsubscribes afterwards" do
+        yielded = nil
+        SubscriberTestSubscriber.subscribe do |instance|
+          yielded = instance
+          assert_kind_of SubscriberTestSubscriber, instance
+        end
+        refute_nil yielded
+      end
+    end
+
+    describe "#process_action" do
+      it "calls a zero argument action" do
+        subscriber.process_action(:hello, nil)
+        assert_equal [:hello], subscriber.received
+      end
+
+      it "calls an action with keyword arguments, symbolizing string keys" do
+        subscriber.process_action(:show, "message" => "hi there")
+        assert_equal [:show, "hi there"], subscriber.received
+      end
+
+      it "uses default arguments when no parameters are supplied" do
+        subscriber.process_action(:show_default, nil)
+        assert_equal [:show_default, "Hello World"], subscriber.received
+      end
+
+      it "ignores an unknown action without raising" do
+        assert_nil subscriber.process_action(:does_not_exist, nil)
+        assert_nil subscriber.received
+      end
+
+      it "rescues ArgumentError when required arguments are missing" do
+        # Missing the required :message keyword argument.
+        subscriber.process_action(:show, {})
+        assert_nil subscriber.received
+      end
+
+      it "rescues StandardError raised inside the action" do
+        subscriber.process_action(:boom, "message" => "kaboom")
+        assert_nil subscriber.received
+      end
+    end
+
+    describe "#process_event" do
+      it "raises NotImplementedError by default" do
+        assert_raises(NotImplementedError) do
+          subscriber.process_event("name", :action, {})
+        end
+      end
+    end
+  end
+end

--- a/test/subscribers/server_test.rb
+++ b/test/subscribers/server_test.rb
@@ -1,0 +1,202 @@
+require_relative "../test_helper"
+
+class ServerSubscriberTest < Minitest::Test
+  describe RocketJob::Subscribers::Server do
+    let(:server) { RocketJob::Server.create! }
+    let(:supervisor) { RocketJob::Supervisor.new(server) }
+    let(:subscriber) { RocketJob::Subscribers::Server.new(supervisor) }
+
+    before do
+      RocketJob::Server.destroy_all
+      reset_supervisor_state
+    end
+
+    after do
+      RocketJob::Server.destroy_all
+      reset_supervisor_state
+    end
+
+    # The shutdown / event indicators are class level instance variables shared
+    # across the process, so reset them between tests to keep them isolated.
+    def reset_supervisor_state
+      RocketJob::Supervisor.instance_variable_get(:@shutdown).reset
+      RocketJob::Supervisor.instance_variable_get(:@event).reset
+    end
+
+    def event_set?
+      RocketJob::Supervisor.instance_variable_get(:@event).set?
+    end
+
+    describe "#initialize" do
+      it "retains the supplied supervisor" do
+        assert_equal supervisor, subscriber.supervisor
+      end
+    end
+
+    describe "#kill" do
+      it "shuts down and kills the pool for this server" do
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:living_count, 0)
+        pool.expect(:kill, nil)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        subscriber.kill
+
+        assert RocketJob::Supervisor.shutdown?
+        pool.verify
+      end
+
+      it "waits for the pool to terminate when workers are still living" do
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:living_count, 2)
+        pool.expect(:kill, nil)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        subscriber.kill(wait_timeout: 0.1)
+
+        assert RocketJob::Supervisor.shutdown?
+        pool.verify
+      end
+
+      it "ignores the request when it is for a different server" do
+        pool = Minitest::Mock.new
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        subscriber.kill(server_id: "000000000000000000000000")
+
+        refute RocketJob::Supervisor.shutdown?
+        # No interactions expected with the worker pool.
+        pool.verify
+      end
+    end
+
+    describe "#pause" do
+      it "pauses a running server and signals an event" do
+        server.started!
+
+        subscriber.pause
+
+        assert server.paused?
+        assert event_set?
+      end
+
+      it "does not pause a server that cannot be paused but still signals an event" do
+        refute server.may_pause?
+
+        subscriber.pause
+
+        assert server.starting?
+        assert event_set?
+      end
+
+      it "ignores the request when it is for a different server" do
+        server.started!
+
+        subscriber.pause(server_id: "000000000000000000000000")
+
+        assert server.running?
+        refute event_set?
+      end
+    end
+
+    describe "#refresh" do
+      it "signals an event" do
+        subscriber.refresh
+        assert event_set?
+      end
+
+      it "ignores the request when it is for a different server" do
+        subscriber.refresh(name: "someone-else")
+        refute event_set?
+      end
+    end
+
+    describe "#resume" do
+      it "resumes a paused server and signals an event" do
+        server.started!
+        server.pause!
+        assert server.paused?
+
+        subscriber.resume
+
+        assert server.running?
+        assert event_set?
+      end
+
+      it "does not resume a server that cannot be resumed but still signals an event" do
+        server.started!
+        refute server.may_resume?
+
+        subscriber.resume
+
+        assert server.running?
+        assert event_set?
+      end
+    end
+
+    describe "#stop" do
+      it "requests a shutdown" do
+        subscriber.stop
+        assert RocketJob::Supervisor.shutdown?
+      end
+
+      it "ignores the request when it is for a different server" do
+        subscriber.stop(server_id: "000000000000000000000000")
+        refute RocketJob::Supervisor.shutdown?
+      end
+    end
+
+    describe "#thread_dump" do
+      it "logs the worker backtraces" do
+        pool = Minitest::Mock.new
+        pool.expect(:log_backtraces, nil)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        subscriber.thread_dump
+
+        pool.verify
+      end
+
+      it "ignores the request when it is for a different server" do
+        pool = Minitest::Mock.new
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        subscriber.thread_dump(name: "someone-else")
+
+        # No interactions expected with the worker pool.
+        pool.verify
+      end
+    end
+
+    # The private #my_server? predicate decides whether an event applies to this
+    # server. Exercise it through #stop, which has no other side effects.
+    describe "server targeting" do
+      it "acts when neither server_id nor name are supplied" do
+        subscriber.stop
+        assert RocketJob::Supervisor.shutdown?
+      end
+
+      it "acts when the name matches this server" do
+        subscriber.stop(name: server.name)
+        assert RocketJob::Supervisor.shutdown?
+      end
+
+      it "acts when the server_id matches this server" do
+        subscriber.stop(server_id: server.id)
+        assert RocketJob::Supervisor.shutdown?
+      end
+
+      it "ignores a non-matching name" do
+        subscriber.stop(name: "someone-else")
+        refute RocketJob::Supervisor.shutdown?
+      end
+
+      it "ignores a non-matching server_id" do
+        subscriber.stop(server_id: "000000000000000000000000")
+        refute RocketJob::Supervisor.shutdown?
+      end
+    end
+  end
+end

--- a/test/subscribers/worker_test.rb
+++ b/test/subscribers/worker_test.rb
@@ -1,0 +1,218 @@
+require_relative "../test_helper"
+
+class WorkerSubscriberTest < Minitest::Test
+  describe RocketJob::Subscribers::Worker do
+    let(:server) { RocketJob::Server.create! }
+    let(:supervisor) { RocketJob::Supervisor.new(server) }
+    let(:subscriber) { RocketJob::Subscribers::Worker.new(supervisor) }
+    let(:worker_id) { 1 }
+    let(:other_server_id) { "000000000000000000000000" }
+
+    before do
+      RocketJob::Server.destroy_all
+    end
+
+    after do
+      RocketJob::Server.destroy_all
+    end
+
+    # Minimal stand-in for a RocketJob::Worker that records the lifecycle calls
+    # the subscriber makes against it.
+    class FakeWorker
+      attr_reader :calls, :thread
+
+      def initialize(alive: true, thread: nil)
+        @alive  = alive
+        @thread = thread
+        @calls  = []
+      end
+
+      def alive?
+        @alive
+      end
+
+      def shutdown!
+        @calls << :shutdown!
+      end
+
+      def join(timeout)
+        @calls << [:join, timeout]
+      end
+
+      def kill
+        @calls << :kill
+      end
+    end
+
+    # Stand-in for the WorkerPool that returns a preconfigured worker by id.
+    class FakePool
+      attr_reader :requested_ids
+
+      def initialize(worker)
+        @worker        = worker
+        @requested_ids = []
+      end
+
+      def find(id)
+        @requested_ids << id
+        @worker
+      end
+    end
+
+    def stub_pool(worker)
+      pool = FakePool.new(worker)
+      supervisor.instance_variable_set(:@worker_pool, pool)
+      pool
+    end
+
+    describe "#initialize" do
+      it "retains the supplied supervisor" do
+        assert_equal supervisor, subscriber.supervisor
+      end
+    end
+
+    describe "#kill" do
+      it "shuts down, joins, and kills the located worker" do
+        worker = FakeWorker.new
+        stub_pool(worker)
+
+        subscriber.kill(server_id: server.id, worker_id: worker_id, wait_timeout: 0.1)
+
+        assert_equal [:shutdown!, [:join, 0.1], :kill], worker.calls
+      end
+
+      it "defaults the wait_timeout when not supplied" do
+        worker = FakeWorker.new
+        stub_pool(worker)
+
+        subscriber.kill(server_id: server.id, worker_id: worker_id)
+
+        assert_equal [:shutdown!, [:join, 3], :kill], worker.calls
+      end
+
+      it "ignores the request when it is for a different server" do
+        worker = FakeWorker.new
+        pool   = stub_pool(worker)
+
+        subscriber.kill(server_id: other_server_id, worker_id: worker_id)
+
+        assert_empty worker.calls
+        assert_empty pool.requested_ids
+      end
+
+      it "does nothing when the worker cannot be located" do
+        pool = stub_pool(nil)
+
+        subscriber.kill(server_id: server.id, worker_id: worker_id)
+
+        assert_equal [worker_id], pool.requested_ids
+      end
+
+      it "does nothing when the located worker is not alive" do
+        worker = FakeWorker.new(alive: false)
+        stub_pool(worker)
+
+        subscriber.kill(server_id: server.id, worker_id: worker_id)
+
+        assert_empty worker.calls
+      end
+
+      it "does nothing when no worker_id is supplied" do
+        worker = FakeWorker.new
+        pool   = stub_pool(worker)
+
+        subscriber.kill(server_id: server.id, worker_id: nil)
+
+        assert_empty worker.calls
+        assert_empty pool.requested_ids
+      end
+    end
+
+    describe "#stop" do
+      it "shuts down the located worker" do
+        worker = FakeWorker.new
+        stub_pool(worker)
+
+        subscriber.stop(server_id: server.id, worker_id: worker_id)
+
+        assert_equal [:shutdown!], worker.calls
+      end
+
+      it "ignores the request when it is for a different server" do
+        worker = FakeWorker.new
+        pool   = stub_pool(worker)
+
+        subscriber.stop(server_id: other_server_id, worker_id: worker_id)
+
+        assert_empty worker.calls
+        assert_empty pool.requested_ids
+      end
+
+      it "does nothing when the worker cannot be located" do
+        stub_pool(nil)
+
+        # Nothing to assert other than that no error is raised.
+        subscriber.stop(server_id: server.id, worker_id: worker_id)
+      end
+
+      it "does nothing when the located worker is not alive" do
+        worker = FakeWorker.new(alive: false)
+        stub_pool(worker)
+
+        subscriber.stop(server_id: server.id, worker_id: worker_id)
+
+        assert_empty worker.calls
+      end
+    end
+
+    describe "#thread_dump" do
+      it "logs the worker backtrace when it has a live thread" do
+        worker = FakeWorker.new(thread: Thread.current)
+        stub_pool(worker)
+
+        called = false
+        subscriber.logger.stub(:backtrace, ->(*) { called = true }) do
+          subscriber.thread_dump(server_id: server.id, worker_id: worker_id)
+        end
+
+        assert called, "expected the worker backtrace to be logged"
+      end
+
+      it "does not log a backtrace when the worker has no thread" do
+        worker = FakeWorker.new(thread: nil)
+        stub_pool(worker)
+
+        called = false
+        subscriber.logger.stub(:backtrace, ->(*) { called = true }) do
+          subscriber.thread_dump(server_id: server.id, worker_id: worker_id)
+        end
+
+        refute called, "expected no backtrace to be logged without a thread"
+      end
+
+      it "ignores the request when it is for a different server" do
+        worker = FakeWorker.new(thread: Thread.current)
+        pool   = stub_pool(worker)
+
+        called = false
+        subscriber.logger.stub(:backtrace, ->(*) { called = true }) do
+          subscriber.thread_dump(server_id: other_server_id, worker_id: worker_id)
+        end
+
+        refute called
+        assert_empty pool.requested_ids
+      end
+
+      it "does nothing when the worker cannot be located" do
+        stub_pool(nil)
+
+        called = false
+        subscriber.logger.stub(:backtrace, ->(*) { called = true }) do
+          subscriber.thread_dump(server_id: server.id, worker_id: worker_id)
+        end
+
+        refute called
+      end
+    end
+  end
+end

--- a/test/supervisor_test.rb
+++ b/test/supervisor_test.rb
@@ -262,6 +262,38 @@ class SupervisorTest < Minitest::Test
       end
     end
 
+    describe ".register_signal_handlers" do
+      it "installs handlers that request a shutdown" do
+        handlers = {}
+        Signal.stub(:trap, ->(signal, &block) { handlers[signal] = block }) do
+          RocketJob::Supervisor.send(:register_signal_handlers)
+        end
+
+        assert handlers["SIGTERM"], "Expected a SIGTERM handler"
+        assert handlers["INT"], "Expected an INT handler"
+
+        handlers.each_value do |handler|
+          RocketJob::Supervisor.instance_variable_get(:@shutdown).reset
+          handler.call
+          # The handler requests the shutdown from a separate thread.
+          50.times do
+            break if RocketJob::Supervisor.shutdown?
+
+            sleep(0.01)
+          end
+          assert RocketJob::Supervisor.shutdown?, "Expected the handler to request a shutdown"
+        end
+      end
+
+      it "warns rather than raising when handlers cannot be installed" do
+        Signal.stub(:trap, ->(*) { raise "cannot trap" }) do
+          # Should rescue the error internally rather than propagating it.
+          RocketJob::Supervisor.send(:register_signal_handlers)
+        end
+        pass
+      end
+    end
+
     def time_block
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       yield

--- a/test/supervisor_test.rb
+++ b/test/supervisor_test.rb
@@ -1,0 +1,271 @@
+require_relative "test_helper"
+
+class SupervisorTest < Minitest::Test
+  describe RocketJob::Supervisor do
+    let(:server) { RocketJob::Server.create! }
+    let(:supervisor) { RocketJob::Supervisor.new(server) }
+
+    before do
+      RocketJob::Server.destroy_all
+      reset_supervisor_state
+    end
+
+    after do
+      RocketJob::Server.destroy_all
+      reset_supervisor_state
+    end
+
+    # The shutdown / event indicators are class level instance variables shared
+    # across the process, so reset them between tests to keep them isolated.
+    def reset_supervisor_state
+      RocketJob::Supervisor.instance_variable_get(:@shutdown).reset
+      RocketJob::Supervisor.instance_variable_get(:@event).reset
+    end
+
+    describe "#initialize" do
+      it "retains the supplied server" do
+        assert_equal server, supervisor.server
+      end
+
+      it "creates a worker pool for the server" do
+        assert_instance_of RocketJob::WorkerPool, supervisor.worker_pool
+        assert_equal server.name, supervisor.worker_pool.server_name
+      end
+    end
+
+    describe "#synchronize" do
+      it "yields the supplied block" do
+        called = false
+        supervisor.synchronize { called = true }
+        assert called
+      end
+
+      it "returns the value of the block" do
+        assert_equal(42, supervisor.synchronize { 42 })
+      end
+    end
+
+    describe "#stop!" do
+      it "stops a running server" do
+        server.started!
+        assert server.running?
+
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:join, true)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        supervisor.stop!
+
+        assert server.stopping?
+        pool.verify
+      end
+
+      it "does not stop a server that cannot be stopped" do
+        server.started!
+        server.stop!
+        assert server.stopping?
+        refute server.may_stop?
+
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:join, true)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        supervisor.stop!
+
+        assert server.stopping?
+        pool.verify
+      end
+
+      it "waits and refreshes the server while workers are still running" do
+        server.started!
+
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:join, false)
+        pool.expect(:living_count, 2)
+        pool.expect(:join, true)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        supervisor.stop!
+
+        assert_equal 2, server.reload.heartbeat.workers
+        pool.verify
+      end
+    end
+
+    # Runs the supplied block with the event listener and subscribers stubbed out
+    # so that #run does not start real threads or block waiting on MongoDB events.
+    def stub_run_environment(&block)
+      yielder      = ->(_server, &blk) { blk.call }
+      bare_yielder = ->(&blk) { blk.call }
+      RocketJob::Event.stub(:listener, nil) do
+        RocketJob::Subscribers::Server.stub(:subscribe, yielder) do
+          RocketJob::Subscribers::Worker.stub(:subscribe, yielder) do
+            RocketJob::Subscribers::Logger.stub(:subscribe, bare_yielder, &block)
+          end
+        end
+      end
+    end
+
+    describe "#run" do
+      it "starts the server and supervises the pool" do
+        supervise_called = false
+        stop_called      = false
+
+        stub_run_environment do
+          supervisor.stub(:supervise_pool, -> { supervise_called = true }) do
+            supervisor.stub(:stop!, -> { stop_called = true }) do
+              supervisor.run
+            end
+          end
+        end
+
+        assert supervise_called, "Expected supervise_pool to be invoked"
+        assert stop_called, "Expected stop! to be invoked"
+        assert server.reload.running?
+      end
+
+      it "shuts down gracefully when the server document is destroyed" do
+        stub_run_environment do
+          raiser = -> { RocketJob::Server.find("000000000000000000000000") }
+          supervisor.stub(:supervise_pool, raiser) do
+            # Should rescue Mongoid::Errors::DocumentNotFound internally.
+            supervisor.run
+          end
+        end
+
+        assert server.reload.running?
+      end
+
+      it "rescues unexpected exceptions" do
+        stub_run_environment do
+          supervisor.stub(:supervise_pool, -> { raise "boom" }) do
+            # Should rescue the exception internally rather than propagating it.
+            supervisor.run
+          end
+        end
+
+        assert server.reload.running?
+      end
+    end
+
+    describe "#supervise_pool" do
+      it "returns immediately when already shutting down" do
+        RocketJob::Supervisor.shutdown!
+
+        pool = Minitest::Mock.new
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        supervisor.supervise_pool
+
+        # No interactions expected with the worker pool.
+        pool.verify
+      end
+
+      it "prunes and rebalances while the server is running" do
+        server.started!
+
+        pool = Minitest::Mock.new
+        pool.expect(:prune, 0)
+        pool.expect(:rebalance, 0, [server.max_workers, true])
+        pool.expect(:living_count, 3)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        RocketJob::Supervisor.stub(:wait_for_event, ->(_timeout) { RocketJob::Supervisor.shutdown! }) do
+          supervisor.supervise_pool
+        end
+
+        assert_equal 3, server.reload.heartbeat.workers
+        pool.verify
+      end
+
+      it "stops the pool while the server is paused" do
+        server.started!
+        server.pause!
+        assert server.paused?
+
+        pool = Minitest::Mock.new
+        pool.expect(:stop, nil)
+        pool.expect(:prune, 0)
+        pool.expect(:living_count, 0)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        RocketJob::Supervisor.stub(:wait_for_event, ->(_timeout) { RocketJob::Supervisor.shutdown! }) do
+          supervisor.supervise_pool
+        end
+
+        pool.verify
+      end
+
+      it "refreshes the heartbeat when the server is neither running nor paused" do
+        server.started!
+        server.stop!
+        assert server.stopping?
+
+        pool = Minitest::Mock.new
+        pool.expect(:living_count, 0)
+        supervisor.instance_variable_set(:@worker_pool, pool)
+
+        RocketJob::Supervisor.stub(:wait_for_event, ->(_timeout) { RocketJob::Supervisor.shutdown! }) do
+          supervisor.supervise_pool
+        end
+
+        pool.verify
+      end
+    end
+
+    describe ".shutdown?" do
+      it "is false until a shutdown is requested" do
+        refute RocketJob::Supervisor.shutdown?
+      end
+
+      it "is true once a shutdown is requested" do
+        RocketJob::Supervisor.shutdown!
+        assert RocketJob::Supervisor.shutdown?
+      end
+    end
+
+    describe ".shutdown!" do
+      it "sets the shutdown indicator and signals an event" do
+        RocketJob::Supervisor.shutdown!
+        assert RocketJob::Supervisor.shutdown?
+        assert RocketJob::Supervisor.instance_variable_get(:@event).set?
+      end
+    end
+
+    describe ".event!" do
+      it "signals a pending event without requesting shutdown" do
+        RocketJob::Supervisor.event!
+        assert RocketJob::Supervisor.instance_variable_get(:@event).set?
+        refute RocketJob::Supervisor.shutdown?
+      end
+    end
+
+    describe ".wait_for_event" do
+      it "returns immediately when an event is already set" do
+        RocketJob::Supervisor.event!
+        elapsed = time_block { RocketJob::Supervisor.wait_for_event(5) }
+        assert elapsed < 1, "Expected to return immediately, took #{elapsed}s"
+      end
+
+      it "resets the event after waiting" do
+        RocketJob::Supervisor.event!
+        RocketJob::Supervisor.wait_for_event(1)
+        refute RocketJob::Supervisor.instance_variable_get(:@event).set?
+      end
+
+      it "waits for the timeout when no event is set" do
+        elapsed = time_block { RocketJob::Supervisor.wait_for_event(0.2) }
+        assert elapsed >= 0.2, "Expected to wait for the timeout, took #{elapsed}s"
+      end
+    end
+
+    def time_block
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 $LOAD_PATH.unshift File.dirname(__FILE__) + "/../lib"
 ENV["TZ"] = "America/New_York"
 
+# Start SimpleCov before any application code is loaded so coverage is tracked.
+require "simplecov"
+SimpleCov.start do
+  add_filter "/test/"
+end
+
 require "yaml"
 require "minitest/autorun"
 require "minitest/mock"

--- a/test/thread_worker_test.rb
+++ b/test/thread_worker_test.rb
@@ -1,0 +1,52 @@
+require_relative "test_helper"
+
+class ThreadWorkerTest < Minitest::Test
+  describe RocketJob::ThreadWorker do
+    before do
+      # Ensure the worker thread has no jobs to pick up while running.
+      RocketJob::Job.destroy_all
+    end
+
+    after do
+      RocketJob::Job.destroy_all
+    end
+
+    def new_worker
+      RocketJob::ThreadWorker.new(id: 1, server_name: "test:1")
+    end
+
+    it "starts a live worker thread" do
+      worker = new_worker
+      assert worker.alive?
+      refute worker.shutdown?
+    ensure
+      worker.shutdown!
+      worker.join(5)
+    end
+
+    it "shuts down cleanly when requested" do
+      worker = new_worker
+      worker.shutdown!
+      assert worker.shutdown?
+      assert worker.join(5), "Expected the worker thread to stop"
+      refute worker.alive?
+    end
+
+    it "exposes the running thread backtrace" do
+      worker = new_worker
+      assert_kind_of Array, worker.backtrace
+    ensure
+      worker.shutdown!
+      worker.join(5)
+    end
+
+    it "can be killed" do
+      worker = new_worker
+      # Allow the thread to enter #run so the Shutdown exception is handled there.
+      sleep(0.2)
+      worker.kill
+      assert worker.join(5), "Expected the killed worker thread to stop"
+      refute worker.alive?
+    end
+  end
+end

--- a/test/worker_pool_test.rb
+++ b/test/worker_pool_test.rb
@@ -1,0 +1,212 @@
+require_relative "test_helper"
+
+# Require Supervisor explicitly so it is fully loaded before WorkerPool, which
+# requires rocket_job/supervisor/shutdown and would otherwise trigger a
+# circular autoload of Supervisor when this file is run on its own.
+require "rocket_job/supervisor"
+
+class WorkerPoolTest < Minitest::Test
+  # A lightweight stand-in for ThreadWorker that records the calls made to it
+  # without starting a real operating system thread.
+  class FakeWorker
+    attr_reader :id, :server_name, :thread
+    attr_writer :alive
+
+    def initialize(id:, server_name:, alive: true)
+      @id          = id
+      @server_name = server_name
+      @alive       = alive
+      @thread      = Object.new
+      @shutdown    = false
+      @killed      = false
+    end
+
+    def alive?
+      @alive
+    end
+
+    def shutdown!
+      @shutdown = true
+    end
+
+    def shutdown?
+      @shutdown
+    end
+
+    def kill
+      @killed = true
+    end
+
+    def killed?
+      @killed
+    end
+
+    # Mirrors ThreadWorker#join, which returns truthy once the thread has stopped.
+    def join(_timeout = nil) # rubocop:disable Naming/PredicateMethod
+      !@alive
+    end
+  end
+
+  describe RocketJob::WorkerPool do
+    let(:server_name) { "test_server:1234" }
+    let(:pool) { RocketJob::WorkerPool.new(server_name) }
+
+    before do
+      reset_supervisor_state
+    end
+
+    after do
+      reset_supervisor_state
+    end
+
+    def reset_supervisor_state
+      RocketJob::Supervisor.instance_variable_get(:@shutdown).reset
+      RocketJob::Supervisor.instance_variable_get(:@event).reset
+    end
+
+    # Stub ThreadWorker.new so rebalance/add_one builds FakeWorker instances.
+    def stub_thread_worker(&block)
+      builder = lambda do |id:, server_name:|
+        FakeWorker.new(id: id, server_name: server_name)
+      end
+      RocketJob::ThreadWorker.stub(:new, builder, &block)
+    end
+
+    describe "#initialize" do
+      it "retains the server name" do
+        assert_equal server_name, pool.server_name
+      end
+
+      it "starts with no workers" do
+        assert_empty pool.workers
+      end
+    end
+
+    describe "#find" do
+      it "returns the worker with the matching id" do
+        worker = FakeWorker.new(id: 7, server_name: server_name)
+        pool.workers << worker
+        assert_equal worker, pool.find(7)
+      end
+
+      it "returns nil when no worker matches" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name)
+        assert_nil pool.find(99)
+      end
+    end
+
+    describe "#rebalance" do
+      it "starts workers up to max_workers" do
+        stub_thread_worker do
+          pool.rebalance(3)
+        end
+        assert_equal 3, pool.workers.count
+        assert_equal [1, 2, 3], pool.workers.map(&:id)
+        assert(pool.workers.all? { |w| w.server_name == server_name })
+      end
+
+      it "returns 0 when already at max_workers" do
+        3.times { |i| pool.workers << FakeWorker.new(id: i, server_name: server_name) }
+        stub_thread_worker do
+          assert_equal 0, pool.rebalance(3)
+        end
+        assert_equal 3, pool.workers.count
+      end
+
+      it "only starts enough workers to reach max_workers" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name)
+        stub_thread_worker do
+          pool.rebalance(3)
+        end
+        assert_equal 3, pool.workers.count
+      end
+
+      it "does not count dead workers towards the living total" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name, alive: false)
+        stub_thread_worker do
+          pool.rebalance(2)
+        end
+        # The dead worker remains, plus two freshly started workers.
+        assert_equal 3, pool.workers.count
+        assert_equal 2, pool.living_count
+      end
+
+      it "returns -1 and stops adding workers when a shutdown is requested" do
+        stub_thread_worker do
+          RocketJob::Supervisor.shutdown!
+          assert_equal(-1, pool.rebalance(5, true))
+        end
+        # The first worker is always added before the shutdown check.
+        assert_equal 1, pool.workers.count
+      end
+    end
+
+    describe "#prune" do
+      it "returns 0 when all workers are alive" do
+        2.times { |i| pool.workers << FakeWorker.new(id: i, server_name: server_name) }
+        assert_equal 0, pool.prune
+        assert_equal 2, pool.workers.count
+      end
+
+      it "removes dead workers and returns the number removed" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name, alive: true)
+        pool.workers << FakeWorker.new(id: 2, server_name: server_name, alive: false)
+        pool.workers << FakeWorker.new(id: 3, server_name: server_name, alive: false)
+
+        assert_equal 2, pool.prune
+        assert_equal [1], pool.workers.map(&:id)
+      end
+    end
+
+    describe "#stop" do
+      it "tells every worker to shut down" do
+        workers = Array.new(3) { |i| FakeWorker.new(id: i, server_name: server_name) }
+        workers.each { |w| pool.workers << w }
+
+        pool.stop
+
+        assert(workers.all?(&:shutdown?))
+      end
+    end
+
+    describe "#kill" do
+      it "kills every worker and clears the pool" do
+        workers = Array.new(3) { |i| FakeWorker.new(id: i, server_name: server_name) }
+        workers.each { |w| pool.workers << w }
+
+        pool.kill
+
+        assert(workers.all?(&:killed?))
+        assert_empty pool.workers
+      end
+    end
+
+    describe "#join" do
+      it "returns true once all workers have stopped" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name, alive: false)
+        pool.workers << FakeWorker.new(id: 2, server_name: server_name, alive: false)
+
+        assert pool.join(0.01)
+        assert_empty pool.workers
+      end
+
+      it "returns false when a worker does not stop within the timeout" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name, alive: true)
+
+        refute pool.join(0.01)
+        # The still-running worker remains in the pool.
+        assert_equal 1, pool.workers.count
+      end
+    end
+
+    describe "#living_count" do
+      it "counts only the workers that are alive" do
+        pool.workers << FakeWorker.new(id: 1, server_name: server_name, alive: true)
+        pool.workers << FakeWorker.new(id: 2, server_name: server_name, alive: false)
+        pool.workers << FakeWorker.new(id: 3, server_name: server_name, alive: true)
+
+        assert_equal 2, pool.living_count
+      end
+    end
+  end
+end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -75,6 +75,24 @@ class WorkerTest < Minitest::Test
     end
   end
 
+  # Worker that shuts down after a single poll so that #run can be exercised
+  # without looping forever.
+  class OneShotWorker < RocketJob::Worker
+    def initialize(**args)
+      super
+      @poll_count = 0
+    end
+
+    def shutdown?
+      @poll_count.positive?
+    end
+
+    def wait_for_shutdown?(_timeout = nil)
+      @poll_count += 1
+      false
+    end
+  end
+
   describe RocketJob::Worker do
     let(:job) { SimpleJob.new }
     let(:throttled_job) { ThrottledJob.new }
@@ -105,6 +123,40 @@ class WorkerTest < Minitest::Test
 
     after do
       RocketJob::Job.destroy_all
+    end
+
+    describe "inline worker defaults" do
+      it "exposes the supplied id and server name" do
+        w = RocketJob::Worker.new(id: 5, server_name: "server:1")
+        assert_equal 5, w.id
+        assert_equal "server:1", w.server_name
+        assert_equal "server:1:5", w.name
+      end
+
+      it "behaves as a single always-alive worker" do
+        assert worker.alive?
+        assert worker.join
+        assert worker.kill
+        assert worker.shutdown!
+        refute worker.shutdown?
+        refute worker.wait_for_shutdown?
+        assert_kind_of Array, worker.backtrace
+      end
+    end
+
+    describe "#run" do
+      it "processes an available job and then stops" do
+        SimpleJob.create!
+        OneShotWorker.new.run
+        # SimpleJob destroys itself on completion.
+        assert_equal 0, SimpleJob.count
+      end
+
+      it "stops cleanly when there is no work" do
+        # Should complete without raising even though no jobs are queued.
+        OneShotWorker.new.run
+        assert_equal 0, SimpleJob.count
+      end
     end
 
     describe "#random_wait_interval" do


### PR DESCRIPTION
## Summary

Substantially expands the test suite, raising line coverage to **95.2%** (697 tests, all passing). This branch also wires up SimpleCov so coverage is tracked on every run.

Work was driven by per-file coverage data: the lowest-covered core files were targeted first, focusing on runtime/model logic that previously had no tests.

## Coverage highlights

| Area | Before → After |
|------|----------------|
| `worker_pool.rb` | 45% → 98% |
| `thread_worker.rb` | 55% → 100% |
| `supervisor/shutdown.rb` (signal handlers) | 66% → 100% |
| `server/model.rb` (zombies, counts_by_state) | 84% → 100% |
| `batch/categories.rb` (v5→v6 migration) | 59% → 95% |
| `sliced/input.rb` (upload_arel / upload_mongo_query) | 58% → 97% |
| `event.rb` (pub/sub, capped collection) | 66% → 76% |
| `worker.rb` (run loop) | 72% → 92% |
| `batch/io.rb`, `batch/model.rb`, `batch/worker.rb` | up to 88–97% |
| `plugins/job/model.rb`, `dirmon_entry.rb`, `upload_file_job.rb` | meaningful gains |
| Subscriber / Subscribers / Document plugin | new suites |

## Notable testing approaches

- **Real worker threads** are exercised via `ThreadWorker`, plus a one-shot `Worker` subclass to drive `#run` for a single poll without looping forever.
- **Signal handlers** are tested by stubbing `Signal.trap` to capture and invoke the installed handlers.
- **Legacy document migration** is triggered with `Mongoid::Factory.from_db`, which fires `after_initialize` with `new_record? == false`.
- **ActiveRecord paths** (`upload_arel`) use an inline sqlite schema, mirroring the existing transaction test.
- Class-level shared state (`Supervisor`, `Event`, `Subscriber`) is reset between tests to avoid leakage.

## Docs

`CLAUDE.md` gains a "Test conventions and gotchas" section recording the above patterns (coverage tooling, autoload ordering pitfalls, state reset, the `from_db` migration trick) for future contributors.

## Test plan

- `bundle exec rake test` — 697 tests, 2131 assertions, 0 failures, 0 errors.
- `bundle exec rubocop` clean on all newly added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)