### PR TITLE
Docs: address MongoDB adoption objections (licensing + fit)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,23 @@ worker. That works until your needs grow past it:
 * You want to *see* what is queued, running, and failed, and change a job's priority or retry it,
   without shelling into a console.
 
+### Is Rocket Job the right fit?
+
+If you need conventional background jobs (send an email, update a record) and nothing more, a
+Redis-backed queue like Sidekiq or a database-backed one like Solid Queue will be simpler to
+operate, and your Rails app may already include one.
+
+Rocket Job is worth adding when your work outgrows that model:
+
+* You process files with millions of records and want them handled in parallel across many workers,
+  not ground through one at a time.
+* You need jobs to run in strict business-priority order, with critical work preempting routine
+  work.
+* You want to retry a single failed slice of a large job rather than restarting the whole thing.
+
+It is built for the large-batch, high-priority end of the spectrum, and it runs ordinary jobs
+perfectly well too.
+
 ### The Rocket Job way
 
 A job is an ordinary class with real fields:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,31 @@ Rocket Job's cross-process event mechanism (used for shutdown, pause, and log-le
 on a *tailable capped collection*. [Amazon DocumentDB](https://aws.amazon.com/documentdb/) does not
 support capped collections, so it cannot run Rocket Job. Use a real MongoDB server.
 
+## Licensing
+
+A frequent objection to adopting Rocket Job is MongoDB's
+[Server Side Public License](https://www.mongodb.com/legal/licensing/server-side-public-license)
+(SSPL), which is not OSI-approved. It is worth being precise about what it does and does not require,
+because the concern is usually broader than the license actually is.
+
+* **Rocket Job and its client stack are permissively licensed.** Rocket Job is Apache 2.0. The gems
+  it uses to talk to the database, the [`mongo`](https://github.com/mongodb/mongo-ruby-driver) driver
+  and [`mongoid`](https://github.com/mongodb/mongoid), are Apache 2.0 as well. Nothing in the
+  Rocket Job stack is SSPL.
+* **The SSPL covers the MongoDB server, and its copyleft only triggers on offering MongoDB itself as
+  a service to third parties.** Running MongoDB internally as the datastore behind your own
+  application and job queue does not create an SSPL obligation. The clause is aimed at companies that
+  resell a managed MongoDB-as-a-service, not at companies that simply run MongoDB.
+* **A commercial license is available.** Organizations with a commercial agreement with MongoDB Inc.
+  can use MongoDB under that license instead, which removes the SSPL question entirely.
+
+This licensing shift is also not unique to MongoDB. [Redis](https://redis.io/) (2024) and
+[Elasticsearch](https://www.elastic.co/) (2021) both moved to SSPL, and both have since re-added an
+OSI-approved option. MongoDB remains a deliberate design choice for Rocket Job: its atomic
+`find_and_modify` is what lets thousands of workers claim jobs and slices without colliding, and it
+spills from memory to disk, which is what makes processing very large files practical. See
+[Architecture](architecture.html) for why the datastore is MongoDB specifically.
+
 ## Install MongoDB
 
 Rocket Job stores all job data in [MongoDB](https://www.mongodb.com). The simplest way to run it


### PR DESCRIPTION
## Summary

Documentation-only changes that tackle the most common objection to adopting Rocket Job: its MongoDB dependency.

- **`installation.md` — new Licensing section.** Reframes the MongoDB SSPL concern accurately:
  - Rocket Job is Apache 2.0, and the client gems it ships (`mongo`, `mongoid`) are Apache 2.0 too, so nothing in the stack is SSPL.
  - The SSPL copyleft only triggers when you offer MongoDB *itself* as a service to third parties; running it internally as your queue's datastore creates no obligation.
  - A commercial MongoDB license is available as an alternative.
  - Notes that Redis (2024) and Elasticsearch (2021) took the same path, so the license reflex is industry-wide, not a Mongo-specific red flag. Closes with the positive case (atomic `find_and_modify`, spill-to-disk) linking to `architecture.html`.
- **`index.md` — new "Is Rocket Job the right fit?" section.** Sets expectations against Sidekiq / Solid Queue and steers users toward the large-batch, high-priority use case Rocket Job is built for.

FerretDB is deliberately not mentioned, to avoid pulling the conversation into a Postgres / Solid Queue comparison.

## Test plan

Docs only; no code changes. Rendered prose reviewed for the kramdown TOC and link conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)