### PR TITLE
Pluggable polling event listener (AWS DocumentDB support)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,12 +27,25 @@ exercised in CI are the authoritative list; see
   support MongoDB server 3.6 through 8.x. See the
   [Mongoid compatibility matrix](https://www.mongodb.com/docs/mongoid/current/compatibility/).
 
-### AWS DocumentDB is not supported
+### AWS DocumentDB
 {:.no_toc}
 
-Rocket Job's cross-process event mechanism (used for shutdown, pause, and log-level changes) relies
-on a *tailable capped collection*. [Amazon DocumentDB](https://aws.amazon.com/documentdb/) does not
-support capped collections, so it cannot run Rocket Job. Use a real MongoDB server.
+Rocket Job's cross-process event mechanism (used for shutdown, pause, and log-level changes)
+defaults to a *tailable capped collection*, which [Amazon DocumentDB](https://aws.amazon.com/documentdb/)
+does not support. To run on DocumentDB, switch the event listener to the polling strategy, which uses
+a regular collection instead. Add this to an initializer (for example
+`config/initializers/rocketjob.rb`):
+
+~~~ruby
+RocketJob::Event.listener_strategy = :polling
+~~~
+
+With polling enabled, control events are delivered within `RocketJob::Event.poll_interval` seconds
+(default `1`). Events are stored in a regular collection bounded by a TTL index;
+`RocketJob::Event.event_retention_seconds` (default one hour) controls how long an event is kept,
+which is also the longest a server can be offline and still recover events on restart. On a real
+MongoDB server the default capped-collection strategy remains the lowest-latency choice and needs no
+configuration.
 
 ## Install MongoDB
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,19 @@ which is also the longest a server can be offline and still recover events on re
 MongoDB server the default capped-collection strategy remains the lowest-latency choice and needs no
 configuration.
 
+#### Event listener settings
+{:.no_toc}
+
+All of the event listener settings, with their defaults:
+
+| Setting | Default | Applies to | Description |
+|---------|---------|-----------|-------------|
+| `RocketJob::Event.listener_strategy` | `:capped` | both | `:capped` tails a capped collection (lowest latency, requires capped-collection support); `:polling` polls a regular collection (works on any MongoDB-compatible store, including DocumentDB). |
+| `RocketJob::Event.long_poll_seconds` | `300` | `:capped` | How long the tailable cursor waits for new events before re-issuing. |
+| `RocketJob::Event.capped_collection_size` | `134217728` (128 MB) | `:capped` | Size of the capped collection, used only when it is first created. |
+| `RocketJob::Event.poll_interval` | `1` | `:polling` | Seconds between polls. Bounds control-event delivery latency. |
+| `RocketJob::Event.event_retention_seconds` | `3600` (1 hour) | `:polling` | TTL on stored events. Also the longest a server can be offline and still recover events on restart. |
+
 ## Install MongoDB
 
 Rocket Job stores all job data in [MongoDB](https://www.mongodb.com). The simplest way to run it

--- a/lib/rocket_job/event.rb
+++ b/lib/rocket_job/event.rb
@@ -12,6 +12,11 @@ module RocketJob
 
     ALL_EVENTS = "*".freeze
 
+    # MongoDB OperationFailure codes that are safe to ignore when concurrently
+    # creating the polling collection and its TTL index:
+    #   48 NamespaceExists, 85 IndexOptionsConflict, 86 IndexKeySpecsConflict.
+    IGNORABLE_CREATE_CODES = [48, 85, 86].freeze
+
     # Capped collection long polling interval.
     class_attribute :long_poll_seconds, instance_accessor: false
     self.long_poll_seconds = 300
@@ -22,6 +27,28 @@ module RocketJob
     # Default: 128MB.
     class_attribute :capped_collection_size, instance_accessor: false
     self.capped_collection_size = 128 * 1024 * 1024
+
+    # Event listener strategy:
+    #   :capped  - Tail a capped collection with a tailable cursor (default).
+    #              Lowest latency, but requires a data store that supports capped
+    #              collections and tailable cursors (i.e. a real MongoDB server).
+    #   :polling - Poll a regular collection for new events. Slightly higher latency
+    #              (bounded by `poll_interval`), but works on any MongoDB-compatible
+    #              store, including AWS DocumentDB which has no capped collections.
+    class_attribute :listener_strategy, instance_accessor: false
+    self.listener_strategy = :capped
+
+    # Polling strategy: seconds to wait between polls for new events.
+    class_attribute :poll_interval, instance_accessor: false
+    self.poll_interval = 1
+
+    # Polling strategy: seconds an event is retained before a TTL index removes it.
+    # Must comfortably exceed the longest expected listener downtime so that a
+    # restarting server can still recover events published while it was away.
+    #
+    # Default: 1 hour.
+    class_attribute :event_retention_seconds, instance_accessor: false
+    self.event_retention_seconds = 60 * 60
 
     # Mandatory Event Name
     #   Examples:
@@ -81,14 +108,23 @@ module RocketJob
       @subscribers.each_value { |v| v.delete_if { |i| i.object_id == handle } }
     end
 
-    # Indefinitely tail the capped collection looking for new events.
+    # Indefinitely watch for new events, dispatching each to its subscribers.
     #   time: the start time from which to start looking for new events.
     def self.listener(time: @load_time)
       Thread.current.name = "rocketjob event"
-      create_capped_collection
 
-      logger.info("Event listener started")
-      tail_capped_collection(time) { |event| process_event(event) }
+      case listener_strategy
+      when :capped
+        create_capped_collection
+        logger.info("Event listener started (capped collection)")
+        tail_capped_collection(time) { |event| process_event(event) }
+      when :polling
+        create_polling_collection
+        logger.info("Event listener started (polling, interval: #{poll_interval}s)")
+        poll_collection(time) { |event| process_event(event) }
+      else
+        raise(ArgumentError, "Unknown RocketJob::Event.listener_strategy: #{listener_strategy.inspect}")
+      end
     rescue Exception => e
       logger.error("#listener Event listener is terminating due to unhandled exception", e)
       raise(e)
@@ -132,6 +168,50 @@ module RocketJob
     rescue Mongo::Error::SocketError, Mongo::Error::SocketTimeoutError, Mongo::Error::OperationFailure, Timeout::Error => e
       logger.info("Creating a new cursor and trying again: #{e.class.name} #{e.message}")
       retry
+    end
+
+    # Create the regular (non-capped) collection used by the polling strategy,
+    # along with a TTL index that expires old events.
+    #
+    # Safe to call repeatedly: it never drops data, and tolerates the collection
+    # and index already existing.
+    def self.create_polling_collection
+      collection.client[collection_name].create unless collection_exists?
+      collection.indexes.create_one({created_at: 1}, expire_after: event_retention_seconds)
+    rescue Mongo::Error::OperationFailure => e
+      # Ignore "collection already exists" and "index already exists" races between
+      # multiple servers starting at once. Anything else is a real error.
+      raise(e) unless IGNORABLE_CREATE_CODES.include?(e.code)
+    end
+
+    # Indefinitely poll a regular collection for new events.
+    #   time: the start time from which to start looking for new events.
+    #
+    # After the first poll the `_id` of the last event seen is used as the
+    # watermark, which is monotonic and unique, so events sharing a `created_at`
+    # timestamp are never skipped.
+    def self.poll_collection(time, &block)
+      last_id = nil
+      loop do
+        last_id = poll_once(time, last_id, &block)
+        sleep(poll_interval)
+      end
+    rescue Mongo::Error::SocketError, Mongo::Error::SocketTimeoutError, Mongo::Error::OperationFailure, Timeout::Error => e
+      logger.info("Polling failed, retrying: #{e.class.name} #{e.message}")
+      sleep(poll_interval)
+      retry
+    end
+
+    # Perform a single polling pass, yielding every event newer than the watermark
+    # and returning the new watermark (the `_id` of the last event seen, or the
+    # supplied `last_id` when no new events were found).
+    def self.poll_once(time, last_id = nil)
+      filter = last_id ? {_id: {"$gt" => last_id}} : {created_at: {"$gt" => time}}
+      collection.find(filter).sort(_id: 1).each do |doc|
+        last_id = doc["_id"]
+        yield(Mongoid::Factory.from_db(Event, doc))
+      end
+      last_id
     end
 
     # Process a new event, calling registered subscribers.

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -193,5 +193,95 @@ class EventTest < Minitest::Test
         end
       end
     end
+
+    describe "polling collection" do
+      before do
+        RocketJob::Event.collection.drop
+      end
+
+      after do
+        RocketJob::Event.collection.drop
+      end
+
+      describe ".create_polling_collection" do
+        it "creates a regular, non-capped collection" do
+          RocketJob::Event.create_polling_collection
+
+          assert_predicate RocketJob::Event, :collection_exists?
+          refute_predicate RocketJob::Event.collection, :capped?
+        end
+
+        it "creates a TTL index on created_at" do
+          RocketJob::Event.create_polling_collection
+
+          ttl_index = RocketJob::Event.collection.indexes.find { |i| i["key"] == {"created_at" => 1} }
+
+          refute_nil ttl_index, "expected a created_at index"
+          assert_equal RocketJob::Event.event_retention_seconds, ttl_index["expireAfterSeconds"]
+        end
+
+        it "is idempotent when called repeatedly" do
+          RocketJob::Event.create_polling_collection
+          # Should not raise on the second call.
+          RocketJob::Event.create_polling_collection
+
+          assert_predicate RocketJob::Event, :collection_exists?
+        end
+      end
+
+      describe ".poll_once" do
+        before do
+          RocketJob::Event.create_polling_collection
+        end
+
+        it "yields events newer than the start time" do
+          start = Time.now.utc - 1
+          RocketJob::Event.create!(name: "EventTestRecorder", action: :hello)
+
+          seen = []
+          RocketJob::Event.poll_once(start) { |event| seen << event }
+
+          assert_equal ["EventTestRecorder"], seen.map(&:name)
+        end
+
+        it "ignores events at or before the start time" do
+          RocketJob::Event.create!(name: "EventTestRecorder", action: :hello)
+          future = Time.now.utc + 60
+
+          seen = []
+          RocketJob::Event.poll_once(future) { |event| seen << event }
+
+          assert_empty seen
+        end
+
+        it "returns the last _id as the watermark and uses it on the next pass" do
+          start = Time.now.utc - 1
+          first = RocketJob::Event.create!(name: "EventTestRecorder", action: :hello)
+
+          watermark = RocketJob::Event.poll_once(start) { |_event| nil }
+
+          assert_equal first.id, watermark
+
+          # A second pass from the watermark sees only newer events, not the first one.
+          second = RocketJob::Event.create!(name: "EventTestRecorder", action: :hello)
+
+          seen = []
+          RocketJob::Event.poll_once(start, watermark) { |event| seen << event }
+
+          assert_equal [second.id], seen.map(&:id)
+        end
+
+        it "does not skip events sharing a created_at timestamp" do
+          start = Time.now.utc - 1
+          stamp = Time.now.utc
+          two   = Array.new(2) { RocketJob::Event.create!(name: "EventTestRecorder", action: :hello, created_at: stamp) }
+
+          seen = []
+          RocketJob::Event.poll_once(start) { |event| seen << event }
+
+          assert_equal two.map(&:id).sort, seen.map(&:id).sort
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Removes the hard capped-collection dependency from Rocket Job's cross-process event mechanism, so it can run on MongoDB-compatible stores that lack capped collections, notably **AWS DocumentDB**.

The control plane (shutdown, pause/resume, log-level changes, secret-config refresh, server/worker commands) publishes by inserting an `Event` document and consumes by tailing a **capped collection** with a `:tailable_await` cursor. Tailable cursors require a capped collection, which is the *only* reason DocumentDB could not host Rocket Job.

The publish path (`Event#save!`) was already store-agnostic, so only the listener side needed to branch.

## What changed

`RocketJob::Event.listener_strategy` selects how the listener consumes events:

- **`:capped`** (default) — the existing tailable capped-collection listener. **Unchanged behavior and lowest latency**; no configuration needed on a real MongoDB server.
- **`:polling`** — polls a regular collection bounded by a TTL index. Works on any MongoDB-compatible store, including DocumentDB.

To run on DocumentDB:

~~~ruby
# config/initializers/rocketjob.rb
RocketJob::Event.listener_strategy = :polling
~~~

New config knobs (polling only):

- `poll_interval` (default `1s`) — control-event delivery latency.
- `event_retention_seconds` (default `1h`) — the TTL on stored events, and the longest a server can be offline and still recover events on restart. Mirrors the capped collection's roll-off behavior.

### Correctness note

Polling advances its watermark by the **last `_id` seen** (monotonic and unique) rather than a `created_at` timestamp, so two events sharing a millisecond timestamp are never skipped. The first pass uses `created_at > start_time` to pick up where the listener began, then switches to `_id`-based paging.

I chose polling over MongoDB change streams deliberately: change streams require a **replica set**, which would break the documented standalone dev/CI setup (`mongo:8.0` on `127.0.0.1`). Polling needs no replica set and works identically on standalone MongoDB, replica sets, and DocumentDB. For a rare-event control plane the latency cost is irrelevant.

## Test plan

- New `event_test.rb` coverage: `create_polling_collection` (creates a regular, non-capped collection with a TTL index on `created_at`; idempotent), and `poll_once` (yields events after the start time, ignores older events, returns/advances the `_id` watermark, and does not skip events sharing a `created_at`).
- Full `event_test.rb`, `supervisor_test.rb`, `subscriber_test.rb`, and `subscribers/*` suites pass.
- `rubocop` clean on changed files.
- Capped-collection default path is untouched.

## Docs

`installation.md`: replaced "AWS DocumentDB is not supported" with DocumentDB setup instructions using the polling strategy.

> Note: depends on / overlaps the docs PR #47 in the same `installation.md` region (DocumentDB + Licensing). Whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)