### PR TITLE
Capture throttle reason and surface it in Mission Control

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -642,6 +642,10 @@ class MyJob < RocketJob::Job
 end
 ~~~
 
+As with simple jobs, pass a `description:` (a String, or a Proc receiving the job and slice) to set
+the reason shown in Mission Control while slices are throttled. It is recorded on the job in
+`throttled_by` and cleared once slices resume processing.
+
 ### Processing windows
 
 `RocketJob::Batch::ThrottleWindows` restricts when slices may be processed, which is useful for a

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -855,6 +855,10 @@ end
 Throttles limit how much work of a given kind runs at once, so jobs cannot overwhelm shared
 resources.
 
+Whenever a throttle holds a job back, the reason is recorded on the job in the `throttled_by` field
+(with `throttled_at`) and shown in Mission Control, so it is clear why a job is sitting in `queued`
+rather than running. The reason is cleared automatically once the job is allowed to start.
+
 ### Throttle Running Jobs
 
 Because it is common to run hundreds or thousands of workers, an unbounded job class could mount a
@@ -941,6 +945,18 @@ class MyJob < RocketJob::Job
   end
 end
 ~~~
+
+Pass a `description:` to control the reason shown in Mission Control when this throttle holds the job
+back. It can be a String, or a Proc that receives the job and returns a String so the reason can
+include runtime detail:
+
+~~~ruby
+define_throttle :mysql_throttle_exceeded?,
+                description: "Throttled: MySQL replica delay exceeds 5 minutes"
+~~~
+
+When no `description:` is given, a humanized form of the method name is used. The same `description:`
+option is available on `define_batch_throttle` for batch jobs.
 
 ## Transactions
 

--- a/lib/rocket_job/batch/throttle.rb
+++ b/lib/rocket_job/batch/throttle.rb
@@ -45,11 +45,16 @@ module RocketJob
         #     Or, a block that will return the filter.
         #     Default: :throttle_filter_class (Throttle all jobs of this class)
         #
+        #   description: [String|Proc]
+        #     Human readable reason why the job is throttled, persisted to `throttled_by`
+        #     and shown in Mission Control. A Proc is called with the job and slice and
+        #     must return a String. Default: a humanized version of the method name.
+        #
         # Note: Throttles are executed in the order they are defined.
-        def define_batch_throttle(method_name, filter: :throttle_filter_class)
+        def define_batch_throttle(method_name, filter: :throttle_filter_class, description: nil)
           # Duplicate to prevent modifying parent class throttles
           definitions = rocket_job_batch_throttles ? rocket_job_batch_throttles.dup : ThrottleDefinitions.new
-          definitions.add(method_name, filter)
+          definitions.add(method_name, filter, description)
           self.rocket_job_batch_throttles = definitions
         end
 

--- a/lib/rocket_job/batch/throttle_running_workers.rb
+++ b/lib/rocket_job/batch/throttle_running_workers.rb
@@ -36,7 +36,11 @@ module RocketJob
 
         validates :throttle_running_workers, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
 
-        define_batch_throttle :throttle_running_workers_exceeded?, filter: :throttle_filter_id
+        define_batch_throttle :throttle_running_workers_exceeded?,
+                              filter:      :throttle_filter_id,
+                              description: lambda { |job, *|
+                                "Throttled: maximum of #{job.throttle_running_workers} running workers reached"
+                              }
       end
 
       private

--- a/lib/rocket_job/batch/throttle_windows.rb
+++ b/lib/rocket_job/batch/throttle_windows.rb
@@ -43,7 +43,9 @@ module RocketJob
         # Duration in seconds of the secondary window.
         field :secondary_duration, type: Integer, class_attribute: true, user_editable: true, copy_on_restart: true
 
-        define_batch_throttle :throttle_windows_exceeded?, filter: :throttle_filter_id
+        define_batch_throttle :throttle_windows_exceeded?,
+                              filter:      :throttle_filter_id,
+                              description: "Throttled: outside of its processing window"
 
         validates_each :primary_schedule, :secondary_schedule do |record, attr, value|
           record.errors.add(attr, "Invalid #{attr}: #{value.inspect}") if value && !Fugit::Cron.new(value)

--- a/lib/rocket_job/batch/worker.rb
+++ b/lib/rocket_job/batch/worker.rb
@@ -111,13 +111,50 @@ module RocketJob
       end
 
       def rocket_job_batch_throttled?(slice, worker)
-        filter = self.class.rocket_job_batch_throttles.matching_filter(self, slice)
-        return false unless filter
+        throttle = self.class.rocket_job_batch_throttles.matching_throttle(self, slice)
+        unless throttle
+          rocket_job_clear_throttled
+          return false
+        end
 
         # Restore retrieved slice so that other workers can process it later.
         slice.set(worker_name: nil, state: :queued, started_at: nil)
-        worker.add_to_current_filter(filter)
+        worker.add_to_current_filter(throttle.extract_filter(self, slice))
+        rocket_job_set_throttled(throttle.extract_description(self, slice))
         true
+      end
+
+      # Record why this batch job's slices are being throttled, for visibility in
+      # Mission Control.
+      #
+      # Unlike a simple job, a running batch job document is shared by every worker
+      # and is deliberately not written on each poll (see Worker#find_and_assign_job).
+      # The reason is therefore persisted with a guarded conditional update so the
+      # shared document is only written when the reason actually changes, not on
+      # every throttled poll.
+      def rocket_job_set_throttled(reason)
+        return if throttled_by == reason
+
+        self.class.with(write: {w: 1}) do |query|
+          query.where(id: id, state: :running, :throttled_by.ne => reason).
+            update_all("$set" => {throttled_by: reason, throttled_at: Time.now})
+        end
+        self.throttled_by = reason
+      end
+
+      # Clear the throttle reason once slices are flowing again.
+      #
+      # Gated on the in-memory value so a worker that never throttled this job
+      # issues no database round trip per slice; only a worker that previously set
+      # a reason clears it, with a guarded update to avoid a redundant write.
+      def rocket_job_clear_throttled
+        return if throttled_by.nil?
+
+        self.class.with(write: {w: 1}) do |query|
+          query.where(id: id, :throttled_by.ne => nil).
+            update_all("$unset" => {throttled_by: "", throttled_at: ""})
+        end
+        self.throttled_by = nil
       end
 
       # Process a single slice from Mongo

--- a/lib/rocket_job/plugins/job/throttle.rb
+++ b/lib/rocket_job/plugins/job/throttle.rb
@@ -30,6 +30,13 @@ module RocketJob
 
         included do
           class_attribute :rocket_job_throttles
+
+          # Human readable reason why this job is currently being throttled.
+          # Set when a throttle prevents the job from running, cleared when it starts.
+          # Surfaced in Rocket Job Mission Control.
+          field :throttled_by, type: String
+          # Time at which this job was last throttled.
+          field :throttled_at, type: Time
         end
 
         module ClassMethods
@@ -45,11 +52,16 @@ module RocketJob
           #     Or, a block that will return the filter.
           #     Default: :throttle_filter_class (Throttle all jobs of this class)
           #
+          #   description: [String|Proc]
+          #     Human readable reason why the job is throttled, persisted to `throttled_by`
+          #     and shown in Mission Control. A Proc is called with the job and must
+          #     return a String. Default: a humanized version of the method name.
+          #
           # Note: Throttles are executed in the order they are defined.
-          def define_throttle(method_name, filter: :throttle_filter_class)
+          def define_throttle(method_name, filter: :throttle_filter_class, description: nil)
             # Duplicate to prevent modifying parent class throttles
             definitions = rocket_job_throttles ? rocket_job_throttles.deep_dup : ThrottleDefinitions.new
-            definitions.add(method_name, filter)
+            definitions.add(method_name, filter, description)
             self.rocket_job_throttles = definitions
           end
 

--- a/lib/rocket_job/plugins/job/throttle_running_jobs.rb
+++ b/lib/rocket_job/plugins/job/throttle_running_jobs.rb
@@ -32,7 +32,10 @@ module RocketJob
           # Allow jobs to be throttled by group name instance of the job class name.
           field :throttle_group, type: String, class_attribute: true, user_editable: true, copy_on_restart: true
 
-          define_throttle :throttle_running_jobs_exceeded?
+          define_throttle :throttle_running_jobs_exceeded?,
+                          description: lambda { |job, *|
+                            "Throttled: maximum of #{job.throttle_running_jobs} running jobs reached"
+                          }
         end
 
         private

--- a/lib/rocket_job/plugins/throttle_dependent_jobs.rb
+++ b/lib/rocket_job/plugins/throttle_dependent_jobs.rb
@@ -13,8 +13,13 @@ module RocketJob
       included do
         field :dependent_jobs, type: Array, class_attribute: true, user_editable: true, copy_on_restart: true
 
-        define_throttle :dependent_jobs_running?
-        define_batch_throttle :dependent_jobs_running? if respond_to?(:define_batch_throttle)
+        dependent_jobs_description = lambda { |job, *|
+          "Throttled: dependent jobs are running (#{Array(job.dependent_jobs).join(', ')})"
+        }
+        define_throttle :dependent_jobs_running?, description: dependent_jobs_description
+        if respond_to?(:define_batch_throttle)
+          define_batch_throttle :dependent_jobs_running?, description: dependent_jobs_description
+        end
       end
 
       class_methods do

--- a/lib/rocket_job/throttle_definition.rb
+++ b/lib/rocket_job/throttle_definition.rb
@@ -1,10 +1,18 @@
 module RocketJob
   class ThrottleDefinition
-    attr_reader :method_name, :filter
+    attr_reader :method_name, :filter, :description
 
-    def initialize(method_name, filter)
+    # Parameters:
+    #   description: [String|Proc|nil]
+    #     Human readable reason why the job is throttled, persisted to the job as
+    #     `throttled_by` and surfaced in Mission Control.
+    #     When a Proc, it is called with the same arguments as the throttle and must
+    #     return a String, allowing the reason to include runtime detail.
+    #     When nil, a humanized version of the method name is used.
+    def initialize(method_name, filter, description = nil)
       @method_name = method_name.to_sym
       @filter      = filter
+      @description = description
     end
 
     # Returns [true|false] whether the throttle was triggered.
@@ -32,6 +40,15 @@ module RocketJob
       else
         job.send(filter)
       end
+    end
+
+    # Returns [String] the human readable reason why the job is throttled.
+    def extract_description(job, *)
+      return description.call(job, *) if description.is_a?(Proc)
+      return description if description
+
+      # Default: humanize the method name, dropping a trailing `?` or `_exceeded`.
+      method_name.to_s.sub(/_exceeded\?\z/, "").sub(/\?\z/, "").tr("_", " ").capitalize
     end
   end
 end

--- a/lib/rocket_job/throttle_definitions.rb
+++ b/lib/rocket_job/throttle_definitions.rb
@@ -6,13 +6,13 @@ module RocketJob
       @throttles = []
     end
 
-    def add(method_name, filter)
+    def add(method_name, filter, description = nil)
       unless filter.is_a?(Symbol) || filter.is_a?(Proc)
         raise(ArgumentError, "Filter for #{method_name} must be a Symbol or Proc")
       end
       raise(ArgumentError, "Cannot define #{method_name} twice, undefine previous throttle first") if exist?(method_name)
 
-      @throttles += [ThrottleDefinition.new(method_name, filter)]
+      @throttles += [ThrottleDefinition.new(method_name, filter, description)]
     end
 
     # Undefine a previously defined throttle
@@ -25,15 +25,20 @@ module RocketJob
       throttles.any? { |throttle| throttle.method_name == method_name }
     end
 
+    # Returns [ThrottleDefinition] the first throttle that was triggered,
+    # or nil if no throttles were triggered.
+    #
+    # The returned definition exposes both the filter (`extract_filter`) and the
+    # human readable reason (`extract_description`) so callers can apply the filter
+    # and persist why the job was throttled.
+    def matching_throttle(job, *args)
+      throttles.find { |throttle| throttle.throttled?(job, *args) }
+    end
+
     # Returns the matching filter,
     # or nil if no throttles were triggered.
-    def matching_filter(job, *args)
-      throttles.each do |throttle|
-        next unless throttle.throttled?(job, *args)
-
-        return throttle.extract_filter(job, *args)
-      end
-      nil
+    def matching_filter(job, *)
+      matching_throttle(job, *)&.extract_filter(job, *)
     end
 
     def deep_dup

--- a/lib/rocket_job/worker.rb
+++ b/lib/rocket_job/worker.rb
@@ -159,12 +159,19 @@ module RocketJob
     # Whether the supplied job has been throttled and should be ignored.
     def throttled_job?(job)
       # Evaluate job throttles, if any.
-      filter = job.rocket_job_throttles.matching_filter(job)
-      return false unless filter
+      throttle = job.rocket_job_throttles.matching_throttle(job)
+      return false unless throttle
 
-      add_to_current_filter(filter)
-      # Restore retrieved job so that other workers can process it later
-      job.set(worker_name: nil, state: :queued)
+      add_to_current_filter(throttle.extract_filter(job))
+      # Restore retrieved job so that other workers can process it later, recording
+      # why it was throttled so it is visible in Mission Control. This reuses the
+      # write that requeues the job, so it adds no extra database round trip.
+      job.set(
+        worker_name:  nil,
+        state:        :queued,
+        throttled_by: throttle.extract_description(job),
+        throttled_at: Time.now
+      )
       true
     end
 
@@ -204,7 +211,12 @@ module RocketJob
           # Queued job: claim it atomically, guarding on it still being queued.
           # find_one_and_update returns the pre-image (state: queued) so that the
           # caller still runs throttles and `start!`.
-          update  = {"$set" => {"worker_name" => name, "state" => "running"}}
+          # Clear any stale throttle reason from a previous throttled poll so a job
+          # that is now allowed to run no longer reports as throttled in Mission Control.
+          update = {
+            "$set"   => {"worker_name" => name, "state" => "running"},
+            "$unset" => {"throttled_by" => "", "throttled_at" => ""}
+          }
           claimed = RocketJob::Job.queued.where(id: job.id).
                     find_one_and_update(update, bypass_document_validation: true)
           return claimed if claimed

--- a/test/plugins/job/throttle_test.rb
+++ b/test/plugins/job/throttle_test.rb
@@ -55,6 +55,34 @@ module Plugins
         end
       end
 
+      class RunningJobsDescriptionJob < RocketJob::Job
+        self.throttle_running_jobs = 7
+
+        def perform
+          21
+        end
+      end
+
+      class DescribedThrottleJob < RocketJob::Job
+        define_throttle :static_throttle, description: "Custom static reason"
+        define_throttle :proc_throttle, description: ->(job, *) { "Reason for #{job.class.name}" }
+        define_throttle :default_throttle_exceeded?
+
+        private
+
+        def static_throttle
+          false
+        end
+
+        def proc_throttle
+          false
+        end
+
+        def default_throttle_exceeded?
+          false
+        end
+      end
+
       describe RocketJob::Plugins::Job::Throttle do
         before do
           RocketJob::Job.delete_all
@@ -92,6 +120,53 @@ module Plugins
             ThrottleJob.define_throttle(:throttle_running_jobs_exceeded?)
 
             assert ThrottleJob.throttle?(:throttle_running_jobs_exceeded?), ThrottleJob.rocket_job_throttles.throttles
+          end
+        end
+
+        describe "throttle descriptions" do
+          let(:throttles) { DescribedThrottleJob.rocket_job_throttles }
+
+          it "uses a static description string" do
+            throttle = throttles.throttles.find { |t| t.method_name == :static_throttle }
+
+            assert_equal "Custom static reason", throttle.extract_description(DescribedThrottleJob.new)
+          end
+
+          it "evaluates a Proc description" do
+            throttle = throttles.throttles.find { |t| t.method_name == :proc_throttle }
+
+            assert_equal "Reason for #{DescribedThrottleJob.name}", throttle.extract_description(DescribedThrottleJob.new)
+          end
+
+          it "humanizes the method name when no description is given" do
+            throttle = throttles.throttles.find { |t| t.method_name == :default_throttle_exceeded? }
+
+            assert_equal "Default throttle", throttle.extract_description(DescribedThrottleJob.new)
+          end
+
+          it "describes the running jobs throttle with the limit" do
+            throttle = RunningJobsDescriptionJob.rocket_job_throttles.throttles.find { |t| t.method_name == :throttle_running_jobs_exceeded? }
+
+            assert_equal "Throttled: maximum of 7 running jobs reached", throttle.extract_description(RunningJobsDescriptionJob.new)
+          end
+        end
+
+        describe "#matching_throttle" do
+          it "returns the triggered throttle" do
+            job1 = ThrottleJob.new
+            job1.start!
+            job2 = ThrottleJob.new
+
+            throttle = job2.rocket_job_throttles.matching_throttle(job2)
+
+            assert throttle
+            assert_equal :throttle_running_jobs_exceeded?, throttle.method_name
+          end
+
+          it "returns nil when no throttle is triggered" do
+            job = ThrottleJob.new
+
+            assert_nil job.rocket_job_throttles.matching_throttle(job)
           end
         end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -471,6 +471,34 @@ class WorkerTest < Minitest::Test
           assert_equal({:_type.nin => [ThrottledJob.name]}, worker.current_filter)
         end
 
+        it "records the throttle reason on the requeued job" do
+          job1 = ThrottledJob.create!
+          ThrottledJob.new.start!
+
+          assert_nil worker.next_available_job, -> { ThrottledJob.all.to_a.ai }
+
+          job1.reload
+
+          assert_predicate job1, :queued?
+          assert_equal "Throttled: maximum of 1 running jobs reached", job1.throttled_by
+          assert job1.throttled_at, "throttled_at should be set"
+        end
+
+        it "clears a stale throttle reason when the job is later claimed" do
+          job.throttled_by = "Throttled: maximum of 1 running jobs reached"
+          job.throttled_at = Time.now
+          job.save!
+
+          assert found_job = worker.find_and_assign_job, "Failed to find job"
+          assert_equal job.id, found_job.id
+
+          found_job.reload
+
+          assert_predicate found_job, :running?
+          assert_nil found_job.throttled_by
+          assert_nil found_job.throttled_at
+        end
+
         it "allows a higher priority Batch queued job to replace a running one with a lower priority" do
           running_job = BatchThrottleJob.create!
 
@@ -526,6 +554,17 @@ class WorkerTest < Minitest::Test
           assert processing_throttled_batch_job.rocket_job_work(worker, true), -> { processing_throttled_batch_job.input.all.to_a.ai }
 
           assert_equal({:id.nin => [processing_throttled_batch_job.id]}, worker.current_filter)
+        end
+
+        it "records the throttle reason on the batch job document" do
+          processing_throttled_batch_job.input.first.start!
+
+          assert processing_throttled_batch_job.rocket_job_work(worker, true), -> { processing_throttled_batch_job.input.all.to_a.ai }
+
+          processing_throttled_batch_job.reload
+
+          assert_equal "Throttled: maximum of 1 running workers reached", processing_throttled_batch_job.throttled_by
+          assert processing_throttled_batch_job.throttled_at, "throttled_at should be set"
         end
       end
     end


### PR DESCRIPTION
## Problem

In a busy system it is not obvious why a job is being throttled. The throttle filter only ever lived in one worker's memory, so a simple job just sat in `queued` and a throttled batch job made no slice progress, with no recorded reason.

## Change

Record a human readable reason on the job and surface it (paired RJMC PR adds the UI).

- `ThrottleDefinition` gains a `description` (String or Proc); `ThrottleDefinitions#matching_throttle` returns the triggered definition, keeping throttle iteration encapsulated (`matching_filter` still works).
- `define_throttle` / `define_batch_throttle` accept `description:`.
- New persisted `throttled_by` / `throttled_at` fields, defaulting to nil so existing jobs still load. Present on simple and batch jobs.
- **Simple jobs**: the reason is written in the *same* write that already requeues a throttled job (no extra round trip) and cleared in the atomic claim, so a job now allowed to run no longer reports as throttled.
- **Batch jobs**: the shared running job document is deliberately not written per poll (write-contention hotspot). The reason is persisted with a *guarded conditional update* so it only writes when the reason changes, and is cleared when slices resume.
- Built-in throttles (running jobs, running workers, processing windows, dependent jobs) ship descriptions that include the limit.

## Tests

New coverage for description resolution (static / Proc / humanized default), `matching_throttle`, simple-job capture + clear, and batch-job capture. Full suite green (717 tests, 0 failures); rubocop clean.

## Notes

Companion Mission Control PR: reidmorrison/rocketjob_mission_control#feature/throttle-reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)