### PR TITLE
Docs: update repo links from master to main

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -433,9 +433,9 @@ runs.
 Rocket Job is tested against a matrix of Ruby, Mongoid, and Rails versions:
 
 * **Ruby:** MRI 3.2, 3.4, and 4.0 are exercised in CI; JRuby 9.4 or newer is also supported. The
-  authoritative list is the [CI matrix](https://github.com/reidmorrison/rocketjob/blob/master/.github/workflows/ci.yml).
+  authoritative list is the [CI matrix](https://github.com/reidmorrison/rocketjob/blob/main/.github/workflows/ci.yml).
 * **Mongoid:** 8.1, 9.0, and 9.1, as defined in
-  [Appraisals](https://github.com/reidmorrison/rocketjob/blob/master/Appraisals).
+  [Appraisals](https://github.com/reidmorrison/rocketjob/blob/main/Appraisals).
 * **Rails / Active Record:** 7.2, 8.0, and 8.1, each paired with the Mongoid versions above (also
   in `Appraisals`). Rails is optional; Rocket Job runs equally well standalone.
 * **MongoDB server:** whatever your Mongoid version supports. Mongoid 8.1 through 9.1 currently
@@ -443,8 +443,8 @@ Rocket Job is tested against a matrix of Ruby, Mongoid, and Rails versions:
   [Mongoid compatibility matrix](https://www.mongodb.com/docs/mongoid/current/compatibility/).
 
 These are the combinations run in CI. See
-[ci.yml](https://github.com/reidmorrison/rocketjob/blob/master/.github/workflows/ci.yml) and
-[Appraisals](https://github.com/reidmorrison/rocketjob/blob/master/Appraisals) for the current,
+[ci.yml](https://github.com/reidmorrison/rocketjob/blob/main/.github/workflows/ci.yml) and
+[Appraisals](https://github.com/reidmorrison/rocketjob/blob/main/Appraisals) for the current,
 authoritative list.
 
 ## Next steps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,8 +17,8 @@ Rocket Job runs with or without Rails. This guide covers both, plus the optional
 
 Rocket Job is tested against a matrix of Ruby, Mongoid, and Rails versions. The combinations
 exercised in CI are the authoritative list; see
-[ci.yml](https://github.com/reidmorrison/rocketjob/blob/master/.github/workflows/ci.yml) and
-[Appraisals](https://github.com/reidmorrison/rocketjob/blob/master/Appraisals).
+[ci.yml](https://github.com/reidmorrison/rocketjob/blob/main/.github/workflows/ci.yml) and
+[Appraisals](https://github.com/reidmorrison/rocketjob/blob/main/Appraisals).
 
 * **Ruby:** MRI 3.2, 3.4, and 4.0. JRuby 9.4 or newer is also supported.
 * **Mongoid:** 8.1, 9.0, and 9.1.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -195,7 +195,7 @@ V3 replaces MongoMapper with Mongoid, which supports the latest MongoDB Ruby cli
 ### Mongo config file
 
 Replace `mongo.yml` with `mongoid.yml`. Start with the sample
-[mongoid.yml](https://github.com/reidmorrison/rocketjob/blob/master/test/config/mongoid.yml).
+[mongoid.yml](https://github.com/reidmorrison/rocketjob/blob/main/test/config/mongoid.yml).
 
 Note: the `rocketjob` and `rocketjob_slices` clients in the above `mongoid.yml` file are both
 required.


### PR DESCRIPTION
The default branch was renamed from `master` to `main`. This updates the six published `github.com/reidmorrison/rocketjob/blob/master/...` links to `blob/main/...` so they resolve directly instead of relying on GitHub's rename redirects.

**Changed:** `docs/index.md` (3 links), `docs/installation.md` (2), `docs/upgrading.md` (1).

Left untouched intentionally: `Seconds_Behind_Master` (MySQL replication term) and the `mongoid/master/` docs URL — neither is a git ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)